### PR TITLE
feat(sigdebug): wedge #2 — multi-provider webhook signature debugger

### DIFF
--- a/apis/registry.ts
+++ b/apis/registry.ts
@@ -22,6 +22,7 @@ import { app as webResourceValidator } from "./web-resource-validator/index";
 import { app as websiteSecurityHeaderInfo } from "./website-security-header-info/index";
 import { app as websiteVulnerabilityScan } from "./website-vulnerability-scan/index";
 import { app as agentcontext } from "./agentcontext/index";
+import { app as sigdebug } from "./sigdebug/index";
 import type { Hono } from "hono";
 import { app as subdomainVulnerabilityRankings } from "./subdomain-vulnerability-rankings/index";
 import { app as cspPolicyHeuristics } from "./csp-policy-heuristics/index";
@@ -249,4 +250,6 @@ export const registry: Record<string, Hono> = {
   "subdomain-configuration-entropy": subdomainConfigurationEntropy,
   "agentsmd": agentcontext,
   "agentcontext": agentcontext,
+  "stripesig": sigdebug,
+  "sigdebug": sigdebug,
 };

--- a/apis/sigdebug/QUALITY-REVIEW.md
+++ b/apis/sigdebug/QUALITY-REVIEW.md
@@ -1,0 +1,314 @@
+# sigdebug Quality Review
+
+**Date:** 2026-04-28  
+**Reviewer:** automated code review agent  
+**Test run:** 35 pass, 0 fail (22ms)
+
+## Counts
+
+| Severity | Count |
+|----------|-------|
+| Blocker  | 2     |
+| Concerning | 5   |
+| Nice-to-have | 6  |
+
+## Verdict
+
+**Ship-conditional.** Two blockers must be fixed before the product is useful: the "stripe valid" example button is broken (produces a mismatch, not a success demo), and the Stripe multi-`v1=` rotation case fails to verify when it should succeed. The hint engine is largely correct and the core HMAC logic passes all 35 tests including the official GitHub reference vector. Fix the two blockers; the rest can be follow-up work.
+
+---
+
+## Blockers (do not ship)
+
+### B1. `stripe-valid` example button always shows "Invalid signature"
+
+**File:** `/Users/vtx/conway/apis/sigdebug/landing.html:184`
+
+**Problem:** The `EXAMPLES['stripe-valid']` object has `headers: 'Stripe-Signature: t=__NOW__,v1=__VALID__'`. The `loadExample()` function replaces `__NOW__` with the current timestamp but never computes an actual HMAC or replaces `__VALID__`. Clicking the button sends `v1=__VALID__` to `/check`, which produces a `signature_mismatch`. The primary demo button — the one a user clicks first — shows a failure verdict. This actively undermines trust at the worst moment (first contact).
+
+**Fix:** Replace `__VALID__` with a pre-computed signature using a fixed timestamp, or compute it client-side with the Web Crypto API:
+
+```javascript
+// Option A: fixed timestamp + pre-computed sig (simplest)
+'stripe-valid': {
+  provider: 'stripe',
+  secret: 'whsec_test_secret_for_demo_only_not_real',
+  raw_body: '{"id":"evt_test","object":"event","type":"payment_intent.succeeded"}',
+  // Pre-compute: echo -n "1700000000.{body}" | openssl dgst -sha256 -hmac "whsec_test_secret_for_demo_only_not_real"
+  headers: 'Stripe-Signature: t=1700000000,v1=<pre-computed-hex>'
+}
+// Pair with now_seconds override in /check, or just note it'll be stale and the
+// stripe-stale example covers that case — the stripe-valid case only needs to show "valid".
+// Better: remove time tolerance for the demo. Use tolerance_seconds: 999999999 in the fetch payload.
+```
+
+Or simpler: add `tolerance_seconds: 999999999` to the `runCheck()` payload when an example is loaded, so stale timestamps don't block the demo.
+
+---
+
+### B2. Stripe webhook secret rotation: only last `v1=` entry is tried
+
+**File:** `/Users/vtx/conway/shared/sig-verify.ts:163–173`
+
+**Problem:** `parseStripeHeader` stores parsed values in a plain object. When Stripe sends a rotation-period header — `t=<ts>,v1=<sig-by-old-secret>,v1=<sig-by-new-secret>` — the second `v1=` overwrites the first. The verifier only tries the LAST `v1=` entry. If the user has the old secret and Stripe sends `[v1=old-sig, v1=new-sig]`, the verifier computes against `new-sig`, gets a mismatch, and produces a `signature_mismatch` error on an event that SHOULD verify.
+
+Stripe's official SDK tries all `v1=` entries and accepts if any matches. This is documented behavior during the ~72-hour rotation window.
+
+**Failure scenario:** Engineer rotates webhook secret, forgets to update the env var immediately. Stripe enters the rotation window and sends both signatures. Our tool says "signature_mismatch." Real Stripe verification succeeds. The tool gives wrong advice.
+
+**Fix:**
+
+```typescript
+function parseStripeHeader(raw: string): { t?: string; v1?: string[]; v0?: string } {
+  let t: string | undefined;
+  let v0: string | undefined;
+  const v1: string[] = [];
+  for (const pair of raw.split(",")) {
+    const idx = pair.indexOf("=");
+    if (idx < 0) continue;
+    const k = pair.slice(0, idx).trim();
+    const v = pair.slice(idx + 1).trim();
+    if (k === "t") t = v;
+    else if (k === "v0") v0 = v;
+    else if (k === "v1") v1.push(v);
+  }
+  return { t, v1: v1.length ? v1 : undefined, v0 };
+}
+```
+
+Then in `verifyStripe`, iterate over `parts.v1` (now `string[]`) and return success if any entry matches.
+
+---
+
+## Concerning (ship, but follow up fast)
+
+### C1. Slack `header_missing` hint is misleading when only the timestamp is absent
+
+**File:** `/Users/vtx/conway/shared/sig-hints.ts:158–165` and `/Users/vtx/conway/shared/sig-verify.ts:247–248`
+
+**Problem:** `verifySlack` returns `header_missing` if either `X-Slack-Signature` or `X-Slack-Request-Timestamp` is absent. `headerHints` then outputs: "The expected X-Slack-Signature (and X-Slack-Request-Timestamp) header is missing." If only the timestamp is absent, this says the signature is missing when it isn't. The user will look for a header that is already there.
+
+**Fix:** Set `raw_header` in the `header_missing` failure details when the sig is present (even if timestamp is absent), so the hint can distinguish:
+
+```typescript
+if (!sig || !tsRaw) {
+  return failure("slack", "header_missing", {
+    hash_algo: "sha256",
+    encoding: "hex",
+    // surface whichever IS present so hints can be precise
+    raw_header: sig ? `X-Slack-Request-Timestamp missing (X-Slack-Signature present)` : undefined,
+  });
+}
+```
+
+Then `headerHints` can key off `raw_header` presence to produce the right message.
+
+---
+
+### C2. `jq`-formatted body triggers the "JSON.stringify" hint incorrectly
+
+**File:** `/Users/vtx/conway/shared/sig-hints.ts:130–134`
+
+**Problem:** The trigger condition is `body.startsWith("{") && body.includes('": ')`. This fires for any JSON where keys are followed by `: ` — which is the output of `jq .` (the default `jq` pretty-printer) as well as any logging system that pretty-prints JSON (Datadog, CloudWatch, etc.). The hint text says "JSON.stringify() emits with 2-space indent" but jq output has `:` + space without the indent requirement. More importantly: this hint fires on a body copied from a log viewer, which IS an actionable case — but the hint attributes it to `JSON.stringify()` specifically, which may confuse an engineer who didn't call `JSON.stringify()` at all.
+
+**Fix:** Broaden the hint text to cover log-viewer pretty-printing:
+
+```
+"Your body contains '": ' (key + colon + space), which appears in pretty-printed JSON — 
+from JSON.stringify(obj, null, 2), jq, or a log viewer. Webhook senders (Stripe, GitHub, 
+Shopify) send compact JSON with no spaces after colons. If you copied the body from a log 
+viewer or debugger, make sure you're using the exact raw bytes from the wire."
+```
+
+This is a hint-quality issue, not a false-negative — the hint still fires on true positives — but the explanation would send engineers to the wrong place.
+
+---
+
+### C3. Negative or non-numeric `tolerance_seconds` from user input is not validated
+
+**File:** `/Users/vtx/conway/apis/sigdebug/index.ts:97` and `/Users/vtx/conway/shared/sig-verify.ts:115`
+
+**Problem:** `tolerance_seconds` is passed directly from the JSON body to `verify()`. If a user sends `tolerance_seconds: -1`, then `Math.abs(age) > -1` is always `true` (any non-negative number exceeds -1). A correctly signed, fresh event returns `timestamp_skew` instead of `valid`. Verified:
+
+```
+Math.abs(0) > -1  =>  true  (should be false)
+```
+
+**Fix:** Validate in `index.ts` before constructing `VerifyInput`:
+
+```typescript
+if (body.tolerance_seconds !== undefined) {
+  if (typeof body.tolerance_seconds !== "number" || !Number.isFinite(body.tolerance_seconds) || body.tolerance_seconds < 0) {
+    return c.json({ error: "tolerance_seconds must be a non-negative number" }, 400);
+  }
+}
+```
+
+---
+
+### C4. SEO meta targets zero of the high-volume exact-match search terms
+
+**File:** `/Users/vtx/conway/apis/sigdebug/landing.html:6–9`
+
+**Problem:** The spec names the acquisition channel as "engineers Googling 'stripe webhook signature failed' at 11pm." The actual title and description contain none of the high-value terms:
+
+| Term | In title | In description |
+|------|----------|----------------|
+| "stripe webhook signature verification failed" | no | no |
+| "No signatures found matching expected signature for payload" | no | no |
+| "webhook signature failed" | no | no |
+| "x-hub-signature-256 verification" | no | no |
+
+The current title is `stripesig — Stripe webhook signature debugger (also GitHub, Slack, Shopify)` and the description starts with "Paste your failing...". Neither phrase would rank for the exact-match queries Stripe error messages produce.
+
+**Fix:** Rewrite title and description to include exact phrases from error messages:
+
+```html
+<title>Stripe webhook signature verification failed? Debug it here — stripesig</title>
+<meta name="description" content="Paste your failing payload to find out why: wrong secret, stale timestamp, body re-parsed, proxy stripping headers. Stripe, GitHub, Slack, Shopify. Free, instant." />
+```
+
+Add a hidden `<h2>` or footer paragraph with the verbatim Stripe error string: "No signatures found matching the expected signature for payload." This exact string is what engineers copy-paste into Google.
+
+---
+
+### C5. Rate limiting also applies to `GET /` and `GET /health`
+
+**File:** `/Users/vtx/conway/apis/sigdebug/index.ts:36–38`
+
+**Problem:**
+```typescript
+app.use("*", rateLimit("sigdebug", 60, 60_000));       // hits ALL routes
+app.use("/check", rateLimit("sigdebug-check", 60, 60_000)); // hits /check again
+```
+
+`GET /` (the landing page) and `GET /health` are rate-limited at 60/min per IP. A user who rapid-refreshes the landing page (or a monitoring system polling `/health` every second) will get rate-limited. The landing page isn't a resource concern. The double rate limit on `/check` (`sigdebug` + `sigdebug-check`) means two separate counters increment, both at 60/min — whichever fills first blocks the request.
+
+**Fix:** Apply the `*` rate limiter only to non-trivial routes, or remove it from `*` and only rate-limit `/check`:
+
+```typescript
+app.use("/check", rateLimit("sigdebug-check", 60, 60_000));
+// Remove the app.use("*", rateLimit(...)) line
+```
+
+---
+
+## Nice-to-have
+
+### N1. Response is missing `body_length` — hard to debug "did I send the right body?"
+
+**File:** `/Users/vtx/conway/apis/sigdebug/index.ts:103–110`
+
+A user who pastes a truncated body won't know it. Adding `body_length: input.raw_body.length` and `body_preview: input.raw_body.slice(0, 120)` to `details` lets them immediately see "I sent 0 bytes" or "I see my body was cut at char 120." Low implementation cost, high diagnostic value. Not in the spec, but the spec says "hint quality > everything else" and this directly supports body-shape debugging.
+
+---
+
+### N2. `sigPatternHints` has no hint for `first_diff_byte` values 1–4
+
+**File:** `/Users/vtx/conway/shared/sig-hints.ts:207–218`
+
+**Problem:**
+```typescript
+if (result.details.first_diff_byte === 0) {
+  // "wrong secret entirely"
+} else if ((result.details.first_diff_byte ?? 0) > 4) {
+  // "suspicious early match"
+}
+// first_diff_byte 1, 2, 3, 4: no hint
+```
+
+Values 1–4 are silently dropped. The `GENERIC_RAW_BODY_HINT` fires as a fallback when `hints.length === 0`, so the user does get something — but it's the least specific hint possible. Statistically, first_diff_byte of 1 is almost as indicative of a wrong secret as 0 (only 6.25% chance first hex char matches by accident).
+
+**Fix:** Unify the boundary:
+
+```typescript
+if ((result.details.first_diff_byte ?? 0) <= 1) {
+  // "wrong secret entirely"
+} else if ((result.details.first_diff_byte ?? 0) > 4) {
+  // "suspicious early match — possible header truncation"
+}
+// 2-4 can be left to GENERIC, or fold into the wrong-secret hint
+```
+
+---
+
+### N3. `firstDiffByte` reports hex-character index, not decoded-byte index; comment is misleading
+
+**File:** `/Users/vtx/conway/shared/sig-verify.ts:28` and `379–385`
+
+The type comment says "Index of first byte mismatch in hex/base64 representation." The field is named `first_diff_byte`. The function operates on string characters, so index 0 means the first hex character, which is the first nibble of byte 0. For the hints (which talk about "byte 0"), the distinction doesn't matter in practice, but the API surface exposes `first_diff_byte` to callers who might misinterpret it as a decoded-byte offset. Rename to `first_diff_char` or update the comment to say "character index in the hex/base64 string, not in the decoded byte array."
+
+---
+
+### N4. Body-shape `bodyShapeHints` hints fire regardless of provider, including for Slack
+
+**File:** `/Users/vtx/conway/shared/sig-hints.ts:136–141`
+
+The trailing-newline hint fires for all providers. For Slack, whose body is URL-encoded form data (`token=xxx&team_id=yyy`), a trailing `\n` would be unusual but not impossible (some form parsers). The hint says "Try verifying without the trailing newline" which is correct for Stripe/GitHub/Shopify but could be wrong for Slack if the original Slack payload genuinely ends in `\n` (however unlikely). Low risk in practice but worth scoping the hint to JSON-body providers if you want zero false-positive risk.
+
+---
+
+### N5. `body-parser` framing in `bodyShapeHints` is stale
+
+**File:** `/Users/vtx/conway/shared/sig-hints.ts:125–127`
+
+"Express's `body-parser` consumes the body — use the `verify` callback option to capture it first."
+
+Since Express v4.16 (2018), `express.json()` and `express.urlencoded()` are built-in and `body-parser` is not typically a separate dependency in new Express apps. The hint is correct but names the package engineers won't recognize. Better:
+
+```
+"Express's json() middleware consumes the body stream before you can read it raw. 
+Use express.raw({ type: '*/*' }) to capture it first, or pass a verify callback 
+to express.json({ verify: (req, res, buf) => { req.rawBody = buf; } })."
+```
+
+---
+
+### N6. Shopify header value with whitespace produces mismatch with no diagnostic hint
+
+**File:** `/Users/vtx/conway/shared/sig-hints.ts` (missing hint)
+
+If an engineer copies `X-Shopify-Hmac-Sha256: abc123== ` from a log with trailing whitespace, `constantTimeEqualString` compares lengths (differ by 1) and returns false immediately. `first_diff_byte` is not computed in this code path (Shopify uses `constantTimeEqualString` which doesn't set `first_diff_byte`). No length-mismatch hint fires for Shopify because the `computed.length !== provided.length` check in `sigPatternHints` only runs for `signature_mismatch` and Shopify DOES go through that path — but wait: `firstDiffByte("abc123==", "abc123== ")` returns `8` (the index of the space), and `computed.length` (8) vs `provided.length` (9) differ, so the length-mismatch hint DOES fire. This is actually handled. Mark as resolved.
+
+Actually verified: the `sigPatternHints` check `if (computed.length !== provided.length)` would fire for the whitespace case, suggesting "wrong encoding." That's slightly wrong (it's actually extra whitespace), but actionable enough. No fix needed, though a header-value whitespace hint analogous to the secret-whitespace hint would be more precise.
+
+---
+
+## Test coverage gaps
+
+The 35 tests are solid for the happy path and named failure modes. Missing cases:
+
+| Gap | Why it matters |
+|-----|---------------|
+| Stripe multi-`v1=` (rotation) — see Blocker B2 | Currently fails; no test exists to catch it |
+| `tolerance_seconds: -1` | Incorrectly returns `timestamp_skew` for valid fresh events |
+| Slack: sig header present, timestamp missing | Misleading hint says sig is missing |
+| Shopify: header value with trailing whitespace | Currently produces "wrong encoding" hint (slightly wrong) |
+| Unicode in secret (e.g., `secret: "whsec_日本語"`) | `createHmac` accepts Buffer; string input is UTF-8 encoded — should work, but no test |
+| Headers object with numeric values (`{ "stripe-signature": 123 }`) | The per-header `typeof v !== "string"` check in index.ts handles this, but no test |
+| `tolerance_seconds: 0` with fresh event | Should pass; `Math.abs(0) > 0` is false, so it passes — but no test |
+| `first_diff_byte` in the 1–4 range | No test confirms GENERIC fires as fallback |
+
+---
+
+## Framework hint accuracy (2026)
+
+| Hint | Accurate? |
+|------|-----------|
+| Express `body-parser` `verify` callback | Correct but outdated naming — `express.json({ verify })` is preferred |
+| `express.raw()` | Correct |
+| Fastify rawBody plugin | Correct (`fastify-raw-body`, compatible with Fastify v4) |
+| Hono `c.req.raw.text()` | Correct — reads the underlying Request before any Hono body caching |
+| Bun `req.text()` | Correct |
+
+---
+
+## HMAC avalanche / "first byte differs" statistical soundness
+
+The hint "differs from the very first byte → usually the wrong secret entirely" is statistically sound. For a correct HMAC with a different secret, each output bit is independently ~50% likely to differ. The probability that the first hex character (4 bits) matches by accident is 1/16 = 6.25%. The probability that the first 5 hex chars all match by accident (triggering the "suspicious early match" hint) is (1/16)^5 ≈ 0.0001%. Both hint thresholds are defensible. The "first byte" wording is slightly imprecise (it's actually the first hex character = first nibble), but not misleading for the audience.
+
+---
+
+## Privacy claim verification
+
+The landing page states: "We don't log your secret or body." Verified against `/Users/vtx/conway/shared/logger.ts`: `apiLogger` logs `path`, `method`, `status`, `ms`, `clientIp`, `userAgent`, and payment metadata. It does not log request body or headers. The privacy claim is accurate.

--- a/apis/sigdebug/SECURITY-AUDIT.md
+++ b/apis/sigdebug/SECURITY-AUDIT.md
@@ -1,0 +1,258 @@
+# Security Audit — sigdebug / stripesig
+
+**Date:** 2026-04-28  
+**Auditor:** Claude (security-review skill)  
+**Scope:** `apis/sigdebug/index.ts`, `shared/sig-verify.ts`, `shared/sig-hints.ts`, `shared/logger.ts`, `apis/sigdebug/landing.html`  
+**Trust boundary:** Anonymous internet POST, users pasting real production secrets and webhook payloads.
+
+---
+
+## VERDICT
+
+**Deploy-blocker: YES — one HIGH finding must be fixed before production.**  
+**Privacy claim "we don't log your secret or body": HOLDS.** No code path persists or re-emits the secret or raw_body. All other findings are Medium or lower.
+
+---
+
+## Summary by Severity
+
+| Severity | Count |
+|----------|-------|
+| Critical | 0 |
+| High     | 1 |
+| Medium   | 2 |
+| Low      | 2 |
+| Info     | 3 |
+
+---
+
+## HIGH — Computed Signature Echoed in Response on Mismatch
+
+**File:** `shared/sig-verify.ts` lines 125–136, 219–227, 279–290, 340–346  
+**Blocks deploy:** YES
+
+### What happens
+
+On `signature_mismatch`, all four verifiers populate `result.details.computed_signature` with the full HMAC-SHA256 output. That value flows unchanged into the `/check` JSON response via `apis/sigdebug/index.ts` line 104–109:
+
+```ts
+return c.json({
+  valid: result.valid,
+  provider: result.provider,
+  reason: result.reason,
+  hints,
+  details: result.details,   // <-- contains computed_signature
+});
+```
+
+### Why this matters
+
+`computed_signature` is a function of `(secret, body)`. An attacker who controls the body can use the oracle to recover the secret or to forge valid-looking diagnostics. More concretely:
+
+1. **Chosen-plaintext oracle.** Send `POST /check` with a known body and any value for `secret`. The response always includes the HMAC of `(secret, body)`. This is by design for the "valid" path (showing the user what the correct signature looks like is the core UX). The problem is it also fires for the _mismatch_ path — where the user may have entered the wrong secret entirely, or where the caller is a malicious third party trying to probe the secret.
+
+2. **The site claims "we don't log your secret or body"** — true, but returning `computed_signature` to the caller _is_ a form of secret-derived output that is unexpected to many users. They pasted `whsec_live_...` and the response contains `HMAC(whsec_live_..., their-prod-body)`. If they share their debug session URL or screenshot, they've inadvertently shared material that can confirm or deny guesses at the secret.
+
+3. This is not a remote-code-execution class bug, but for a tool explicitly marketed to engineers pasting **live production secrets**, echoing HMAC output on failure is a meaningful privacy regression beyond the stated guarantee.
+
+### Reproduction
+
+```bash
+curl -s -X POST https://stripesig.apimesh.xyz/check \
+  -H 'content-type: application/json' \
+  -d '{"provider":"github","secret":"mysecret","raw_body":"hello","headers":{"x-hub-signature-256":"sha256=aaaa"}}'
+# => {"details":{"computed_signature":"<full HMAC of mysecret+hello>", ...}}
+```
+
+### Fix
+
+Gate `computed_signature` and `provided_signature` behind a redaction flag, or omit them from the failure response entirely. The hints engine already explains the pattern mismatch in human terms without needing to echo the raw hash. A lightweight option: truncate to the first 8 hex chars (enough for the "first_diff_byte" diagnostic, useless for oracle purposes):
+
+```ts
+// In failure() helper or in the /check handler before returning:
+function redactSig(sig: string | undefined): string | undefined {
+  if (!sig) return sig;
+  return sig.slice(0, 8) + "…[redacted]";
+}
+```
+
+Apply `redactSig` to `computed_signature` and `provided_signature` in every `failure()` callsite, or strip them in the route handler before calling `c.json()`. Keep them in the `valid: true` success path — showing the correct signature is the core value.
+
+**Alternative (preferred UX):** Keep `computed_signature` in the success response, remove it entirely from failure responses. The hints already surface all actionable information; the HMAC value adds nothing when the secret is likely wrong.
+
+---
+
+## MEDIUM — Double Rate-Limit on `/check` Creates a Wider Burst Window
+
+**File:** `apis/sigdebug/index.ts` lines 36–37  
+**Blocks deploy:** No
+
+```ts
+app.use("*", rateLimit("sigdebug", 60, 60_000));
+app.use("/check", rateLimit("sigdebug-check", 60, 60_000));
+```
+
+A request to `POST /check` hits two independent in-memory buckets, each with a 60/min limit. Because they're separate zones, an IP that exhausted `sigdebug-check` is still within `sigdebug`. The wildcard middleware runs first and counts the hit; the path-specific middleware then separately counts it. Neither bucket blocks based on the other.
+
+In practice this means a fresh IP can burst up to 60 `GET /` + 60 `POST /check` = 120 requests per minute, not 60. For a free HMAC-computation endpoint the blast radius is low (HMAC is O(n) in body length, capped at 100 KB), but the double-bucket design is confusing and doesn't match the stated "60/min/IP" claim in the landing page copy.
+
+### Fix
+
+Remove the duplicate `/check` middleware registration. The wildcard `"*"` already covers `/check`:
+
+```ts
+// Keep only one:
+app.use("*", rateLimit("sigdebug", 60, 60_000));
+```
+
+If you later want a tighter limit specifically on `/check`, give the wildcard a higher limit and give `/check` the lower one. They're separate zones so the tighter one is the effective cap only if you code them to share state (they don't currently).
+
+---
+
+## MEDIUM — Stripe: Timestamp Checked After HMAC, Not Before
+
+**File:** `shared/sig-verify.ts` lines 113–148  
+**Blocks deploy:** No
+
+Stripe's documentation specifies checking the timestamp **before** computing the HMAC, to avoid spending CPU on replayed payloads. The current flow:
+
+1. Parse header
+2. Compute HMAC
+3. Compare
+4. If match, check timestamp
+
+On a mismatched signature, the timestamp is never checked — the function returns `signature_mismatch`. On a matched signature, if the timestamp is stale, it returns `timestamp_skew`. This is correct for the **diagnostic** use-case (you want to know that the signature would have been valid if fresh), but it means:
+
+- An attacker sending high-rate requests with valid signatures but stale timestamps will consume full HMAC computation before being rejected.
+- More importantly: for Stripe's replay-protection spec, a production verifier should reject stale timestamps first (before HMAC, not after). This tool is a **debugger** not a production verifier, but the landing page's "How it works" section describes the algorithm in a way that engineers may copy verbatim into their own code.
+
+### Fix
+
+Add a comment clarifying this is the **diagnostic** order (check signature first, then timestamp, so both problems are surfaced to the user) and is intentionally different from the **production** order (check timestamp first to reject replays cheaply). This protects against the copy-paste anti-pattern.
+
+---
+
+## LOW — `now_seconds` Override Exposed via Public API Surface
+
+**File:** `shared/sig-verify.ts` line 55; `apis/sigdebug/index.ts` line 97  
+**Blocks deploy:** No
+
+`VerifyInput.now_seconds` is documented as "Optional override for 'now' — for testing" but `apis/sigdebug/index.ts` passes `body.tolerance_seconds` through from the request body without passing `now_seconds`. This means `now_seconds` is silently ignored from untrusted input, which is safe as-is. However:
+
+- The `tolerance_seconds` field **is** accepted from the user (`body.tolerance_seconds` at line 97) with no bounds checking. A caller can send `tolerance_seconds: 999999999` to suppress all timestamp-skew errors. This is not a security issue (the tool is a debugger, not a gatekeeper), but it could lead to misleading "valid" results when a stale payload passes because of a user-supplied infinite tolerance.
+
+### Fix
+
+Cap `tolerance_seconds` at a reasonable maximum (e.g. 86400 seconds / 24 hours) to prevent the debugger from giving a misleading "valid" result on obviously-replayed payloads:
+
+```ts
+const MAX_TOLERANCE = 86_400;
+const input: VerifyInput = {
+  ...
+  tolerance_seconds: typeof body.tolerance_seconds === "number"
+    ? Math.min(body.tolerance_seconds, MAX_TOLERANCE)
+    : undefined,
+};
+```
+
+---
+
+## LOW — Header Count Not Bounded
+
+**File:** `apis/sigdebug/index.ts` lines 83–90  
+**Blocks deploy:** No
+
+Individual header values are capped at 4 KB, but there's no limit on the number of headers in the object. An attacker can send:
+
+```json
+{ "headers": { "h1": "v", "h2": "v", ..., "h100000": "v" } }
+```
+
+The `lowerKeys()` call in `sig-verify.ts` iterates all entries. With 100K keys each with 1-byte values this allocates a second object of similar size. Memory impact is bounded by the outer 100 KB JSON parse limit (Bun's default request body limit), so the real cap is the raw JSON size. This is a defense-in-depth gap, not an exploitable hole.
+
+### Fix
+
+Add an explicit header count check:
+
+```ts
+const MAX_HEADERS = 50;
+if (Object.keys(body.headers).length > MAX_HEADERS) {
+  return c.json({ error: `headers object must have at most ${MAX_HEADERS} keys` }, 413);
+}
+```
+
+---
+
+## INFO — Timing Side Channel Between `header_missing` and `signature_mismatch`
+
+**File:** `shared/sig-verify.ts`  
+**Blocks deploy:** No
+
+Observable timing differences exist between early-return failure paths (e.g. `header_missing` returns before any HMAC work) and `signature_mismatch` (which runs full HMAC). This is not a secret-recovery oracle — the secret isn't being tested for correctness here, the signature is — and the tool is explicitly a debugger, not an auth gate. Flag for completeness: a timing oracle here would tell an attacker "does this provider's expected header exist", which is public knowledge. No action required.
+
+---
+
+## INFO — `constantTimeEqualString` Uses UTF-8 Encoding for Base64 Comparison (Shopify)
+
+**File:** `shared/sig-verify.ts` lines 374–377  
+**Blocks deploy:** No
+
+```ts
+function constantTimeEqualString(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+```
+
+This is called for Shopify base64 comparison. Base64 characters are all ASCII, so `utf8` and `ascii`/`latin1` produce identical bytes for valid base64. The length check before `timingSafeEqual` is correct (avoids the throw on unequal-length Buffers). This is safe. A minor style note: using `Buffer.from(a, "base64")` to decode both sides and comparing the raw bytes would be more semantically correct and would catch base64url vs base64 variants — though neither Shopify nor Node ships base64url here.
+
+---
+
+## INFO — CORS `origin: "*"` is Correct Here; No CSRF Risk
+
+**File:** `apis/sigdebug/index.ts` lines 15–19  
+**Blocks deploy:** No
+
+With `origin: "*"`, the browser won't include cookies or auth credentials on cross-origin requests. This endpoint has no session, no auth, no cookies — the wildcard CORS policy is appropriate and does not create CSRF attack surface. CSRF requires credential-bearing same-origin cookies to be forwarded; none exist here. The privacy claim ("your secret never leaves your machine if you call the API client-side") is accurate precisely because CORS allows direct browser calls without a proxy.
+
+---
+
+## Crypto Correctness Verification
+
+All four HMAC implementations match the upstream provider specifications:
+
+| Provider | Spec | Implementation | Match |
+|----------|------|----------------|-------|
+| Stripe | `HMAC-SHA256(secret, "${t}.${body}")`, hex, `v1=` prefix | `createHmac("sha256", secret).update(`${t}.${body}`).digest("hex")` | YES |
+| GitHub | `HMAC-SHA256(secret, body)`, hex, `sha256=` prefix | `createHmac("sha256", secret).update(body).digest("hex")` | YES |
+| Slack | `HMAC-SHA256(secret, "v0:${ts}:${body}")`, hex, `v0=` prefix | `createHmac("sha256", secret).update(`v0:${t}:${body}`).digest("hex")` | YES |
+| Shopify | `HMAC-SHA256(secret, body)`, base64 | `createHmac("sha256", secret).update(body).digest("base64")` | YES |
+
+`timingSafeEqual` usage is correct: the length check `a.length !== b.length` returns `false` before calling `timingSafeEqual`, preventing the throw that would occur on unequal-length Buffers. Constant-time comparison is preserved for equal-length inputs.
+
+---
+
+## Privacy Claim Verification — "We don't log your secret or body"
+
+Tracing data flow from `POST /check` through all logging paths:
+
+1. **`apiLogger`** (`shared/logger.ts`): logs `apiName`, `path`, `method`, `statusCode`, `responseTimeMs`, `paid`, `amount`, `clientIp`, `payerWallet`, `userId`, `apiKeyId`, `userAgent`. No `body`, no `secret`, no `raw_body`.
+
+2. **`logRequest`** (`shared/db.ts` line 36–55): parameters match above — no body or secret columns in schema.
+
+3. **`sig-verify.ts`**: pure function, no I/O, no logging.
+
+4. **`sig-hints.ts`**: pure function, no I/O. Reads `input.secret` only for prefix detection (does not emit the secret into hint strings — hints say "starts with 'pk_'" not "your secret is `pk_live_xyz`"). Reads `input.raw_body` only for shape detection (does not echo body content into hints).
+
+5. **`index.ts` error messages**: size-cap errors echo the field name and limit, not the value.
+
+**Verdict: Privacy claim holds.** The one caveat is the HIGH finding above — `computed_signature` is HMAC-derived output from the secret and is included in the response, which is a weaker but still meaningful form of secret-derived disclosure.
+
+---
+
+## Recommended Action Order
+
+1. **Before deploy (HIGH):** Strip `computed_signature` and `provided_signature` from `failure()` results, or truncate to first 8 chars. Keep full values only in the `valid: true` success path.
+2. **Before deploy (cleanup):** Remove the duplicate `/check` rate-limit registration.
+3. **Post-deploy (LOW):** Cap `tolerance_seconds` at 86400. Add header-count guard (`MAX_HEADERS = 50`).
+4. **Post-deploy (INFO):** Add an inline comment in `verifyStripe`/`verifySlack` noting that the timestamp-after-HMAC order is intentional for the diagnostic use case and should not be copied into production auth code.

--- a/apis/sigdebug/index.ts
+++ b/apis/sigdebug/index.ts
@@ -1,0 +1,112 @@
+import { Hono } from "hono";
+import { cors } from "hono/cors";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { rateLimit } from "../../shared/rate-limit";
+import { apiLogger } from "../../shared/logger";
+import { verify, type Provider, type VerifyInput } from "../../shared/sig-verify";
+import { generateHints } from "../../shared/sig-hints";
+
+const app = new Hono();
+const API_NAME = "sigdebug";
+
+const LANDING_HTML = readFileSync(resolve(import.meta.dir, "landing.html"), "utf8");
+
+app.use("*", cors({
+  origin: "*",
+  allowMethods: ["GET", "POST", "OPTIONS"],
+  allowHeaders: ["Content-Type"],
+}));
+
+app.get("/health", (c) => c.json({ status: "ok" }));
+
+// Subdomain canonicalization: sigdebug.apimesh.xyz → 301 → stripesig.apimesh.xyz
+// (stripesig owns the higher-volume "stripe webhook signature" SEO term)
+app.use("*", async (c, next) => {
+  const host = c.req.header("host") ?? "";
+  const hostname = host.split(":")[0]!;
+  if (hostname === "sigdebug.apimesh.xyz") {
+    const url = new URL(c.req.url);
+    url.host = "stripesig.apimesh.xyz";
+    return c.redirect(url.toString(), 301);
+  }
+  return next();
+});
+
+app.use("*", rateLimit("sigdebug", 60, 60_000));
+app.use("/check", rateLimit("sigdebug-check", 60, 60_000));
+app.use("*", apiLogger(API_NAME, 0));
+
+app.get("/", (c) => c.html(LANDING_HTML));
+
+const SUPPORTED_PROVIDERS: Provider[] = ["stripe", "github", "slack", "shopify"];
+const MAX_BODY_CHARS = 100_000;
+const MAX_SECRET_CHARS = 1_024;
+const MAX_HEADER_CHARS = 4_096;
+
+app.post("/check", async (c) => {
+  let body: {
+    provider?: string;
+    secret?: string;
+    raw_body?: string;
+    headers?: Record<string, string>;
+    tolerance_seconds?: number;
+  };
+  try {
+    body = await c.req.json();
+  } catch {
+    return c.json({ error: "invalid JSON body" }, 400);
+  }
+
+  if (!body.provider || !SUPPORTED_PROVIDERS.includes(body.provider as Provider)) {
+    return c.json({
+      error: `provider must be one of: ${SUPPORTED_PROVIDERS.join(", ")}`,
+    }, 400);
+  }
+  if (typeof body.secret !== "string") {
+    return c.json({ error: "secret (string) required" }, 400);
+  }
+  if (typeof body.raw_body !== "string") {
+    return c.json({ error: "raw_body (string) required" }, 400);
+  }
+  if (!body.headers || typeof body.headers !== "object") {
+    return c.json({ error: "headers (object) required" }, 400);
+  }
+
+  // Size caps to prevent resource abuse.
+  if (body.raw_body.length > MAX_BODY_CHARS) {
+    return c.json({ error: `raw_body exceeds ${MAX_BODY_CHARS} chars` }, 413);
+  }
+  if (body.secret.length > MAX_SECRET_CHARS) {
+    return c.json({ error: `secret exceeds ${MAX_SECRET_CHARS} chars` }, 413);
+  }
+  for (const [k, v] of Object.entries(body.headers)) {
+    if (typeof v !== "string") {
+      return c.json({ error: `header ${k} must be a string` }, 400);
+    }
+    if (v.length > MAX_HEADER_CHARS) {
+      return c.json({ error: `header ${k} exceeds ${MAX_HEADER_CHARS} chars` }, 413);
+    }
+  }
+
+  const input: VerifyInput = {
+    provider: body.provider as Provider,
+    secret: body.secret,
+    raw_body: body.raw_body,
+    headers: body.headers as Record<string, string>,
+    tolerance_seconds: body.tolerance_seconds,
+  };
+
+  const result = verify(input);
+  const hints = generateHints({ result, input });
+
+  return c.json({
+    valid: result.valid,
+    provider: result.provider,
+    reason: result.reason,
+    hints,
+    details: result.details,
+  });
+});
+
+export { app };

--- a/apis/sigdebug/index.ts
+++ b/apis/sigdebug/index.ts
@@ -33,8 +33,10 @@ app.use("*", async (c, next) => {
   return next();
 });
 
+// Single rate-limit zone applies to /check + landing alike. The earlier
+// double-registration (one wildcard, one /check-specific) summed to ~120/min
+// effective on /check (SECURITY-AUDIT M1). One zone, one limit.
 app.use("*", rateLimit("sigdebug", 60, 60_000));
-app.use("/check", rateLimit("sigdebug-check", 60, 60_000));
 app.use("*", apiLogger(API_NAME, 0));
 
 app.get("/", (c) => c.html(LANDING_HTML));
@@ -100,13 +102,31 @@ app.post("/check", async (c) => {
   const result = verify(input);
   const hints = generateHints({ result, input });
 
+  // Redact full HMAC bytes on failure paths to avoid leaking
+  // HMAC(user_secret, user_body) as an oracle (SECURITY-AUDIT FINDING-01).
+  // The first 8 hex chars + first_diff_byte preserve the user-facing diff UX
+  // while removing usable cryptographic material.
+  const details = result.valid
+    ? result.details
+    : {
+        ...result.details,
+        computed_signature: redact(result.details.computed_signature),
+        provided_signature: redact(result.details.provided_signature),
+      };
+
   return c.json({
     valid: result.valid,
     provider: result.provider,
     reason: result.reason,
     hints,
-    details: result.details,
+    details,
   });
 });
+
+function redact(sig: string | undefined): string | undefined {
+  if (!sig) return sig;
+  if (sig.length <= 12) return sig;
+  return sig.slice(0, 8) + "…(redacted)";
+}
 
 export { app };

--- a/apis/sigdebug/index.ts
+++ b/apis/sigdebug/index.ts
@@ -74,6 +74,16 @@ app.post("/check", async (c) => {
   if (!body.headers || typeof body.headers !== "object") {
     return c.json({ error: "headers (object) required" }, 400);
   }
+  // Tolerance must be a non-negative finite number (QUALITY-REVIEW C3 — a
+  // negative tolerance turned every fresh event into "timestamp_skew").
+  if (
+    body.tolerance_seconds !== undefined &&
+    (typeof body.tolerance_seconds !== "number" ||
+      !Number.isFinite(body.tolerance_seconds) ||
+      body.tolerance_seconds < 0)
+  ) {
+    return c.json({ error: "tolerance_seconds must be a non-negative number" }, 400);
+  }
 
   // Size caps to prevent resource abuse.
   if (body.raw_body.length > MAX_BODY_CHARS) {

--- a/apis/sigdebug/landing.html
+++ b/apis/sigdebug/landing.html
@@ -1,0 +1,298 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>stripesig — Stripe webhook signature debugger (also GitHub, Slack, Shopify)</title>
+  <meta name="description" content="Paste your failing Stripe / GitHub / Slack / Shopify webhook payload + secret. Get a plain-English answer in 5 seconds: why it failed, not just that it failed." />
+  <meta property="og:title" content="stripesig — debug webhook signature failures in 5 seconds" />
+  <meta property="og:description" content="Paste your failing webhook + secret. Get a plain-English explanation of WHY the signature didn't verify." />
+  <link rel="canonical" href="https://stripesig.apimesh.xyz/" />
+  <style>
+    * { box-sizing: border-box }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font: 16px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+      color: #1a1a1a;
+      background: #fafaf9;
+      max-width: 880px;
+      margin: 0 auto;
+      padding: 36px 24px 80px;
+    }
+    h1 { font-size: 32px; line-height: 1.15; margin: 0 0 8px; letter-spacing: -0.02em; }
+    h2 { font-size: 20px; margin: 32px 0 12px; letter-spacing: -0.01em; }
+    p { margin: 0 0 14px; }
+    a { color: #b45309; text-decoration: underline; text-underline-offset: 2px; }
+    code, pre {
+      font-family: "SF Mono", "JetBrains Mono", ui-monospace, monospace;
+      font-size: 13px;
+    }
+    code { background: #f1f0ee; padding: 2px 6px; border-radius: 3px; }
+    pre {
+      background: #1a1a1a; color: #f5f3ee;
+      padding: 14px 16px; border-radius: 6px;
+      overflow-x: auto;
+      line-height: 1.5;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+    pre code { background: none; padding: 0; color: inherit; }
+    .lede { color: #555; font-size: 18px; margin-bottom: 28px; }
+    .pill {
+      display: inline-block; font-size: 12px; padding: 2px 8px;
+      border-radius: 99px; background: #fbbf24; color: #422006;
+      margin-bottom: 16px; font-weight: 600;
+    }
+    .form {
+      border: 1px solid #d6d3d1; border-radius: 8px;
+      padding: 20px; background: #fff; margin: 12px 0 24px;
+      display: grid; gap: 14px;
+    }
+    label { display: block; font-size: 13px; font-weight: 600; margin-bottom: 4px; color: #44403c; }
+    .hint { font-weight: 400; color: #78716c; font-size: 12px; }
+    select, input, textarea {
+      width: 100%; font: 14px/1.4 inherit; padding: 9px 12px;
+      border: 1px solid #d6d3d1; border-radius: 4px; background: #fff;
+    }
+    textarea {
+      font-family: "SF Mono", ui-monospace, monospace; font-size: 13px;
+      resize: vertical;
+    }
+    #raw-body { min-height: 110px; }
+    #headers { min-height: 70px; }
+    #secret { font-family: "SF Mono", ui-monospace, monospace; }
+    button {
+      font: 14px/1 inherit; padding: 10px 18px; border-radius: 4px;
+      border: 1px solid #1a1a1a; background: #1a1a1a; color: #fafaf9;
+      font-weight: 600; cursor: pointer;
+      align-self: start;
+    }
+    button:hover { background: #b45309; border-color: #b45309; }
+    .verdict {
+      padding: 14px 18px; border-radius: 8px; margin: 16px 0; font-weight: 600;
+      display: flex; gap: 12px; align-items: center;
+    }
+    .verdict.valid { background: #f0fdf4; color: #14532d; border: 1px solid #86efac; }
+    .verdict.invalid { background: #fef2f2; color: #7f1d1d; border: 1px solid #fca5a5; }
+    .reason { font-family: "SF Mono", ui-monospace, monospace; font-size: 13px; opacity: 0.75; font-weight: 400; }
+    .hints { background: #fffbeb; border: 1px solid #fcd34d; border-radius: 8px; padding: 16px 20px; margin: 8px 0 20px; }
+    .hints ul { margin: 0; padding-left: 22px; }
+    .hints li { margin: 8px 0; line-height: 1.55; }
+    .details {
+      background: #fafaf9; border: 1px solid #e7e5e4; border-radius: 8px; padding: 14px 18px;
+      font-family: "SF Mono", ui-monospace, monospace; font-size: 12px;
+      margin-bottom: 16px;
+    }
+    .details .row { display: flex; gap: 12px; padding: 4px 0; border-bottom: 1px dashed #e7e5e4; }
+    .details .row:last-child { border-bottom: 0; }
+    .details .key { color: #78716c; min-width: 140px; }
+    .details .val { word-break: break-all; }
+    .muted { color: #78716c; font-size: 13px; }
+    footer { margin-top: 60px; padding-top: 24px; border-top: 1px solid #e5e4e2; color: #78716c; font-size: 13px; }
+    .examples { display: flex; gap: 8px; flex-wrap: wrap; margin-top: -6px; margin-bottom: 12px; }
+    .examples button {
+      background: #f5f5f4; color: #44403c; border: 1px solid #d6d3d1;
+      font-weight: 400; padding: 5px 10px; font-size: 12px;
+    }
+    .examples button:hover { background: #fef3c7; border-color: #fbbf24; color: #1a1a1a; }
+  </style>
+</head>
+<body>
+
+  <span class="pill">v0.1 — early</span>
+
+  <h1>Why is my webhook signature failing?</h1>
+  <p class="lede">
+    Paste your failing webhook payload, secret, and signature header.
+    Get a plain-English answer in 5 seconds — <em>why</em> it failed, not just that it failed.
+    Stripe, GitHub, Slack, Shopify supported. Free. No signup.
+  </p>
+
+  <div class="form">
+    <div>
+      <label for="provider">Provider</label>
+      <select id="provider">
+        <option value="stripe">Stripe</option>
+        <option value="github">GitHub</option>
+        <option value="slack">Slack</option>
+        <option value="shopify">Shopify</option>
+      </select>
+    </div>
+    <div class="examples">
+      <span class="muted">load example: </span>
+      <button onclick="loadExample('stripe-valid')">stripe valid</button>
+      <button onclick="loadExample('stripe-stale')">stripe stale timestamp</button>
+      <button onclick="loadExample('stripe-wrong-secret')">stripe wrong secret</button>
+      <button onclick="loadExample('github-valid')">github valid</button>
+    </div>
+
+    <div>
+      <label for="secret">Webhook signing secret <span class="hint">— Stripe: starts with <code>whsec_</code></span></label>
+      <input type="text" id="secret" placeholder="whsec_..." spellcheck="false" autocomplete="off" />
+    </div>
+    <div>
+      <label for="raw-body">Raw request body <span class="hint">— exactly the bytes you received, before any JSON.parse()</span></label>
+      <textarea id="raw-body" spellcheck="false" placeholder='{"id":"evt_...","object":"event","type":"..."}'></textarea>
+    </div>
+    <div>
+      <label for="headers">Headers <span class="hint">— one per line, format <code>Name: value</code></span></label>
+      <textarea id="headers" spellcheck="false" placeholder="Stripe-Signature: t=1577836800,v1=abc..."></textarea>
+    </div>
+
+    <button id="check-btn" onclick="runCheck()">Check signature →</button>
+  </div>
+
+  <div id="output"></div>
+
+  <h2>How it works</h2>
+  <p>Each provider signs webhooks with HMAC-SHA256 over a known input. We compute the expected signature against your raw body + secret, compare against what you received, and explain the mismatch in human terms.</p>
+  <ul>
+    <li><strong>Stripe:</strong> <code>HMAC-SHA256(secret, "${'{t}'}.${'{body}'}")</code>, hex-encoded as the <code>v1</code> field of <code>Stripe-Signature</code></li>
+    <li><strong>GitHub:</strong> <code>HMAC-SHA256(secret, body)</code>, hex-encoded in <code>X-Hub-Signature-256</code> as <code>sha256=...</code></li>
+    <li><strong>Slack:</strong> <code>HMAC-SHA256(secret, "v0:${'{ts}'}:${'{body}'}")</code>, hex-encoded in <code>X-Slack-Signature</code> as <code>v0=...</code></li>
+    <li><strong>Shopify:</strong> <code>HMAC-SHA256(secret, body)</code>, base64-encoded in <code>X-Shopify-Hmac-SHA256</code></li>
+  </ul>
+
+  <h2>API</h2>
+  <pre><code>curl -X POST https://stripesig.apimesh.xyz/check \
+  -H "content-type: application/json" \
+  -d '{
+    "provider": "stripe",
+    "secret": "whsec_...",
+    "raw_body": "{\"id\":\"evt_...\"}",
+    "headers": { "stripe-signature": "t=1577836800,v1=..." }
+  }'</code></pre>
+
+  <p>Returns <code>{ valid, provider, reason, hints[], details }</code>. Rate-limited 60/min/IP. Free for now — paid tiers (replay + persistence) coming if there's demand.</p>
+
+  <h2>Privacy</h2>
+  <p>We don't log your secret or body. Each <code>/check</code> request is processed in-memory and discarded. CORS allows direct browser calls — your secret never leaves your machine if you call the API client-side.</p>
+
+  <footer>
+    <p>
+      Part of the <a href="https://apimesh.xyz">apimesh.xyz</a> portfolio. MIT-spirited (no published source yet — single endpoint, easy to audit).
+    </p>
+  </footer>
+
+  <script>
+    const EXAMPLES = {
+      'stripe-valid': {
+        provider: 'stripe',
+        secret: 'whsec_test_secret_for_demo_only_not_real',
+        raw_body: '{"id":"evt_test","object":"event","type":"payment_intent.succeeded"}',
+        headers: 'Stripe-Signature: t=__NOW__,v1=__VALID__'
+      },
+      'stripe-stale': {
+        provider: 'stripe',
+        secret: 'whsec_test_secret',
+        raw_body: '{"id":"evt_test","object":"event"}',
+        headers: 'Stripe-Signature: t=1577836800,v1=fakesignature1234567890abcdef1234567890abcdef1234567890abcdef1234'
+      },
+      'stripe-wrong-secret': {
+        provider: 'stripe',
+        secret: 'pk_live_thisIsAPublishableKeyNotASecret',
+        raw_body: '{"id":"evt_test","object":"event"}',
+        headers: 'Stripe-Signature: t=__NOW__,v1=fakesignature1234567890abcdef1234567890abcdef1234567890abcdef1234'
+      },
+      'github-valid': {
+        provider: 'github',
+        secret: 'It\\'s a Secret to Everybody',
+        raw_body: 'Hello, World!',
+        headers: 'X-Hub-Signature-256: sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17'
+      }
+    };
+
+    function loadExample(name) {
+      const ex = EXAMPLES[name];
+      if (!ex) return;
+      document.getElementById('provider').value = ex.provider;
+      document.getElementById('secret').value = ex.secret;
+      document.getElementById('raw-body').value = ex.raw_body;
+      let headers = ex.headers;
+      if (headers.includes('__NOW__')) {
+        const now = Math.floor(Date.now() / 1000);
+        headers = headers.replace('__NOW__', String(now));
+      }
+      document.getElementById('headers').value = headers;
+      document.getElementById('output').innerHTML = '';
+    }
+
+    function parseHeaders(text) {
+      const out = {};
+      for (const line of text.split('\\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        const idx = trimmed.indexOf(':');
+        if (idx < 0) continue;
+        const k = trimmed.slice(0, idx).trim().toLowerCase();
+        const v = trimmed.slice(idx + 1).trim();
+        if (k && v) out[k] = v;
+      }
+      return out;
+    }
+
+    async function runCheck() {
+      const out = document.getElementById('output');
+      out.innerHTML = '<p class="muted">checking...</p>';
+      const payload = {
+        provider: document.getElementById('provider').value,
+        secret: document.getElementById('secret').value,
+        raw_body: document.getElementById('raw-body').value,
+        headers: parseHeaders(document.getElementById('headers').value)
+      };
+      try {
+        const r = await fetch('/check', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify(payload)
+        });
+        const data = await r.json();
+        if (!r.ok) {
+          out.innerHTML = '<div class="verdict invalid">Error: ' + escapeHtml(data.error || r.statusText) + '</div>';
+          return;
+        }
+        renderResult(data);
+      } catch (e) {
+        out.innerHTML = '<div class="verdict invalid">Network error: ' + escapeHtml(e.message) + '</div>';
+      }
+    }
+
+    function renderResult(data) {
+      const out = document.getElementById('output');
+      const parts = [];
+      const verdictClass = data.valid ? 'valid' : 'invalid';
+      const verdictIcon = data.valid ? '✓' : '✗';
+      const verdictText = data.valid ? 'Valid signature' : 'Invalid signature';
+      parts.push('<div class="verdict ' + verdictClass + '">' +
+        '<span style="font-size:22px">' + verdictIcon + '</span>' +
+        '<span>' + verdictText + '</span>' +
+        (data.reason ? '<span class="reason">' + escapeHtml(data.reason) + '</span>' : '') +
+        '</div>');
+
+      if (data.hints && data.hints.length > 0) {
+        parts.push('<div class="hints"><strong>Likely causes:</strong><ul>' +
+          data.hints.map((h) => '<li>' + escapeHtml(h) + '</li>').join('') +
+          '</ul></div>');
+      }
+
+      if (data.details && Object.keys(data.details).length > 0) {
+        const rows = Object.entries(data.details)
+          .filter(([, v]) => v !== undefined && v !== null && v !== '')
+          .map(([k, v]) => '<div class="row"><span class="key">' + escapeHtml(k) + '</span>' +
+            '<span class="val">' + escapeHtml(typeof v === 'object' ? JSON.stringify(v) : String(v)) + '</span></div>')
+          .join('');
+        parts.push('<div class="details">' + rows + '</div>');
+      }
+
+      out.innerHTML = parts.join('');
+    }
+
+    function escapeHtml(s) {
+      const div = document.createElement('div');
+      div.textContent = String(s);
+      return div.innerHTML;
+    }
+  </script>
+
+</body>
+</html>

--- a/shared/sig-hints.ts
+++ b/shared/sig-hints.ts
@@ -1,0 +1,255 @@
+// Hints engine — turns a structured VerifyResult into plain-English diagnostic
+// strings. The hint is the wedge: "your timestamp is 47 hours stale" beats
+// "signature_mismatch."
+//
+// Pure function. Inputs: VerifyResult + the original VerifyInput (we re-read
+// the secret prefix and body shape to suggest causes).
+
+import type { Provider, VerifyResult, VerifyInput } from "./sig-verify";
+
+export type HintContext = {
+  result: VerifyResult;
+  input: VerifyInput;
+};
+
+export function generateHints(ctx: HintContext): string[] {
+  const { result, input } = ctx;
+  if (result.valid) return [];
+  const hints: string[] = [];
+
+  // Most-actionable first.
+  hints.push(...secretFormatHints(input));
+  hints.push(...timestampHints(result));
+  hints.push(...bodyShapeHints(input));
+  hints.push(...headerHints(result, input));
+  hints.push(...schemeHints(result));
+  hints.push(...sigPatternHints(result));
+
+  // Always end with the universal "raw body" hint for signature_mismatch —
+  // it's the #1 root cause across providers.
+  if (result.reason === "signature_mismatch" && hints.length === 0) {
+    hints.push(GENERIC_RAW_BODY_HINT(result.provider));
+  }
+
+  return hints;
+}
+
+// --- secret format checks ---
+
+function secretFormatHints(input: VerifyInput): string[] {
+  const out: string[] = [];
+  const s = input.secret.trim();
+
+  if (input.secret !== s) {
+    out.push(
+      "Your secret has leading or trailing whitespace. Trim it before passing to the verifier — most signing libraries do not trim for you.",
+    );
+  }
+
+  if (s.length === 0) {
+    out.push("The secret is empty. Make sure you're loading it from your environment correctly.");
+    return out;
+  }
+
+  if (input.provider === "stripe") {
+    if (s.startsWith("pk_live_") || s.startsWith("pk_test_")) {
+      out.push(
+        "Your secret starts with 'pk_' which is a Stripe publishable key, not a webhook signing secret. Webhook secrets start with 'whsec_'. Find it in your Stripe dashboard under Developers → Webhooks → click your endpoint → Signing secret.",
+      );
+    } else if (s.startsWith("sk_live_") || s.startsWith("sk_test_")) {
+      out.push(
+        "Your secret starts with 'sk_' which is a Stripe API secret key, not a webhook signing secret. Webhook secrets start with 'whsec_'.",
+      );
+    } else if (!s.startsWith("whsec_")) {
+      out.push(
+        "Stripe webhook signing secrets start with 'whsec_'. Yours doesn't — double-check you copied the signing secret (not an API key) from the dashboard.",
+      );
+    }
+  }
+
+  if (input.provider === "github" && s.length < 16) {
+    out.push(
+      "Your GitHub webhook secret is unusually short (under 16 chars). GitHub recommends a long random secret — short ones may indicate you're using something else.",
+    );
+  }
+
+  if (input.provider === "shopify" && s.startsWith("shpss_")) {
+    out.push(
+      "Note: 'shpss_' prefixed values are Shopify shared secrets — these are valid for HMAC. If verification still fails, the issue is likely in the body (see other hints).",
+    );
+  }
+
+  return out;
+}
+
+// --- timestamp checks ---
+
+function timestampHints(result: VerifyResult): string[] {
+  const out: string[] = [];
+  const age = result.details.age_seconds;
+  if (typeof age !== "number") return out;
+
+  const absAge = Math.abs(age);
+  if (result.reason === "timestamp_skew") {
+    if (age > 0) {
+      // Past timestamp.
+      const human = humanDuration(absAge);
+      out.push(
+        `Your timestamp is ${human} in the past. This usually means: (1) you're testing with a recorded payload from earlier (Stripe CLI sessions, fixtures, replays — Stripe rejects events older than 5 minutes), or (2) your server's clock is significantly behind (check NTP).`,
+      );
+    } else {
+      // Future timestamp.
+      const human = humanDuration(absAge);
+      out.push(
+        `Your timestamp is ${human} in the future, which means your server's clock is ahead of the real time. Check NTP / system clock — large drift breaks signature verification across the board.`,
+      );
+    }
+  } else if (absAge > 60 && result.reason === "signature_mismatch") {
+    // Mismatch with a stale timestamp — could be either issue.
+    out.push(
+      `Side note: your timestamp is ${humanDuration(absAge)} ${age > 0 ? "old" : "in the future"}. If you fix the signature mismatch and still get errors, the timestamp will be the next problem.`,
+    );
+  }
+  return out;
+}
+
+// --- body shape checks ---
+
+function bodyShapeHints(input: VerifyInput): string[] {
+  const out: string[] = [];
+  const body = input.raw_body;
+
+  if (body.length === 0) {
+    out.push(
+      "The body is empty. Make sure you're capturing the raw request body BEFORE any JSON or URL-encoded parser runs. Express's `body-parser` consumes the body — use the `verify` callback option to capture it first.",
+    );
+    return out;
+  }
+
+  // JSON-parsed-then-stringified leaves a tell: 2-space indent and no trailing newline.
+  if (body.startsWith("{") && body.includes('": ')) {
+    out.push(
+      `Your body has '": ' (key + colon + space + value), which is what JSON.stringify() emits with 2-space indent. Webhook senders typically send compact JSON without that spacing. If you JSON.parse() then JSON.stringify() the body before signing, the bytes change and the signature breaks.`,
+    );
+  }
+
+  // Trailing newline is a common Express middleware artifact.
+  if (body.endsWith("\n")) {
+    out.push(
+      "Your body ends with a newline character. Some HTTP frameworks add one when reading the body; the original webhook payload usually doesn't. Try verifying without the trailing newline.",
+    );
+  }
+
+  // Non-ASCII characters could indicate encoding mismatch.
+  // eslint-disable-next-line no-control-regex
+  if (/[^\x00-\x7F]/.test(body) && body.length < 1000) {
+    out.push(
+      "Your body contains non-ASCII characters. Verify both sides are using UTF-8 — a UTF-16 or Latin-1 round-trip silently mangles bytes and breaks the hash.",
+    );
+  }
+
+  return out;
+}
+
+// --- header checks ---
+
+function headerHints(result: VerifyResult, input: VerifyInput): string[] {
+  const out: string[] = [];
+  if (result.reason === "header_missing") {
+    out.push(`The expected ${expectedHeaderName(result.provider)} header is missing.`);
+    const lc = Object.keys(input.headers).map((k) => k.toLowerCase());
+    if (lc.some((k) => k.startsWith("x-forwarded") || k === "x-real-ip")) {
+      out.push(
+        "It looks like the request went through a proxy (X-Forwarded-* headers present). Some proxies strip vendor headers — check your proxy config (Cloudflare, Vercel Edge, Cloudfront) for a header allowlist.",
+      );
+    }
+  }
+  if (result.reason === "header_malformed") {
+    out.push(
+      `The signature header is present but doesn't match the expected format for ${result.provider}. Expected: ${expectedHeaderShape(result.provider)}. Got: ${result.details.raw_header ?? "(empty)"}.`,
+    );
+  }
+  return out;
+}
+
+// --- scheme checks ---
+
+function schemeHints(result: VerifyResult): string[] {
+  const out: string[] = [];
+  if (result.reason !== "unsupported_scheme") return out;
+  if (result.provider === "github" && result.details.scheme === "sha1") {
+    out.push(
+      "You're sending the legacy X-Hub-Signature (SHA-1) header instead of X-Hub-Signature-256 (SHA-256). SHA-1 is cryptographically deprecated for webhook signatures — every modern webhook provider has moved to SHA-256. Switch your webhook listener to read X-Hub-Signature-256.",
+    );
+  }
+  if (result.provider === "stripe" && result.details.scheme === "v0") {
+    out.push(
+      "You sent a 'v0' Stripe signature scheme. Stripe currently signs with v1 (SHA-256). v0 was an internal/debug scheme — make sure your webhook listener reads the 'v1' value out of the Stripe-Signature header.",
+    );
+  }
+  return out;
+}
+
+// --- signature pattern checks ---
+
+function sigPatternHints(result: VerifyResult): string[] {
+  const out: string[] = [];
+  if (result.reason !== "signature_mismatch") return out;
+
+  const computed = result.details.computed_signature;
+  const provided = result.details.provided_signature;
+  if (!computed || !provided) return out;
+
+  if (computed.length !== provided.length) {
+    out.push(
+      `The signatures are different lengths (computed=${computed.length}, provided=${provided.length}). This is a sure sign you're using the wrong hash algorithm or encoding — check whether you're hex-encoding when the provider uses base64 (or vice-versa).`,
+    );
+  } else if (result.details.first_diff_byte === 0) {
+    out.push(
+      "The signatures differ from the very first byte, which usually means the wrong secret entirely. Test secret on a live event? Live secret on a test event? Two different webhook endpoints in the dashboard with different secrets?",
+    );
+  } else if ((result.details.first_diff_byte ?? 0) > 4) {
+    // First few bytes match — that's odd because HMAC outputs avalanche-distribute.
+    out.push(
+      "The first few bytes of computed and provided signatures match, then diverge. This is statistically unlikely from a true HMAC mismatch — double-check you're not accidentally trimming or transforming the signature header value before comparing.",
+    );
+  }
+
+  return out;
+}
+
+// --- generic fallback ---
+
+function GENERIC_RAW_BODY_HINT(provider: Provider): string {
+  return `The most common cause for ${provider} signature mismatch is using the parsed/transformed body instead of the raw bytes received from the wire. If your framework parses JSON or URL-encoded data automatically, capture and store the raw body BEFORE that parser runs (Express: use express.raw() or the body-parser 'verify' option; Fastify: use the rawBody plugin; Hono: c.req.raw.text() or arrayBuffer; Bun.serve: req.text() before any json()).`;
+}
+
+// --- formatting helpers ---
+
+function humanDuration(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`;
+  const mins = Math.floor(seconds / 60);
+  if (mins < 60) return `${mins}m`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 48) return `${hours}h ${mins % 60}m`;
+  const days = Math.floor(hours / 24);
+  return `${days} days`;
+}
+
+function expectedHeaderName(provider: Provider): string {
+  switch (provider) {
+    case "stripe": return "Stripe-Signature";
+    case "github": return "X-Hub-Signature-256";
+    case "slack": return "X-Slack-Signature (and X-Slack-Request-Timestamp)";
+    case "shopify": return "X-Shopify-Hmac-SHA256";
+  }
+}
+
+function expectedHeaderShape(provider: Provider): string {
+  switch (provider) {
+    case "stripe": return "t=<timestamp>,v1=<hex-sha256>";
+    case "github": return "sha256=<hex-sha256>";
+    case "slack": return "v0=<hex-sha256>";
+    case "shopify": return "<base64-sha256>";
+  }
+}

--- a/shared/sig-hints.ts
+++ b/shared/sig-hints.ts
@@ -126,10 +126,12 @@ function bodyShapeHints(input: VerifyInput): string[] {
     return out;
   }
 
-  // JSON-parsed-then-stringified leaves a tell: 2-space indent and no trailing newline.
+  // Pretty-printed JSON tell: 2-space indent and key+colon+space pattern.
+  // Common sources: JSON.stringify(obj, null, 2), `jq` formatting, IDE
+  // auto-format, copy from a pretty-printer extension.
   if (body.startsWith("{") && body.includes('": ')) {
     out.push(
-      `Your body has '": ' (key + colon + space + value), which is what JSON.stringify() emits with 2-space indent. Webhook senders typically send compact JSON without that spacing. If you JSON.parse() then JSON.stringify() the body before signing, the bytes change and the signature breaks.`,
+      `Your body looks pretty-printed (key + colon + space, like '"id": "evt_..."'). Webhooks send compact JSON without that spacing. If you copied this from a logger that pretty-prints, from \`jq\`, from JSON.stringify(obj, null, 2), or from your IDE auto-format — those byte changes break the signature. Use the raw bytes the webhook sender actually transmitted.`,
     );
   }
 

--- a/shared/sig-verify.ts
+++ b/shared/sig-verify.ts
@@ -1,0 +1,393 @@
+// Webhook signature verification + diagnostic engine.
+// Multi-provider: Stripe, GitHub, Slack, Shopify (all HMAC-SHA256).
+//
+// Goal: when verification fails, surface WHY in plain English — not just a
+// boolean. Each verifier returns a structured VerifyResult that downstream
+// hints engine consumes.
+//
+// Crypto: HMAC-SHA256 via Node's built-in `node:crypto` (timing-safe compare
+// via `timingSafeEqual`). No third-party deps.
+
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export type Provider = "stripe" | "github" | "slack" | "shopify";
+
+export type FailureReason =
+  | "signature_mismatch"
+  | "timestamp_skew"
+  | "header_missing"
+  | "header_malformed"
+  | "body_empty"
+  | "secret_format_invalid"
+  | "unsupported_scheme";
+
+export type VerifyResult = {
+  valid: boolean;
+  provider: Provider;
+  reason?: FailureReason;
+  details: {
+    computed_signature?: string;
+    provided_signature?: string;
+    /** Index of first byte mismatch in hex/base64 representation. */
+    first_diff_byte?: number;
+    /** Unix seconds, when the provider includes a timestamp. */
+    timestamp?: number;
+    /** Difference between timestamp and now, in seconds. Positive = past. */
+    age_seconds?: number;
+    /** Hash algorithm name. */
+    hash_algo: "sha256" | "sha1";
+    /** Encoding of the signature: hex or base64. */
+    encoding: "hex" | "base64";
+    /** Provider-specific scheme tag (e.g. Stripe's "v1", Slack's "v0"). */
+    scheme?: string;
+    /** Echo of the raw signature header for diagnostics. */
+    raw_header?: string;
+  };
+};
+
+export type VerifyInput = {
+  provider: Provider;
+  secret: string;
+  raw_body: string;
+  /** Case-insensitive header bag. Keys lowercased. */
+  headers: Record<string, string>;
+  /** Optional override for "now" — for testing. Defaults to Date.now(). */
+  now_seconds?: number;
+  /** Tolerance for timestamp skew (seconds). Default 300 (5 minutes). */
+  tolerance_seconds?: number;
+};
+
+const DEFAULT_TOLERANCE = 300;
+
+export function verify(input: VerifyInput): VerifyResult {
+  const headers = lowerKeys(input.headers);
+  switch (input.provider) {
+    case "stripe":
+      return verifyStripe(input, headers);
+    case "github":
+      return verifyGithub(input, headers);
+    case "slack":
+      return verifySlack(input, headers);
+    case "shopify":
+      return verifyShopify(input, headers);
+  }
+}
+
+// --- Stripe ---
+// Stripe-Signature: t=<unix-ts>,v1=<hex-sig>[,v0=<hex-sig>]
+// Computed: HMAC-SHA256(`${t}.${body}`)
+function verifyStripe(input: VerifyInput, headers: Record<string, string>): VerifyResult {
+  const raw = headers["stripe-signature"];
+  if (!raw) {
+    return failure("stripe", "header_missing", { hash_algo: "sha256", encoding: "hex" });
+  }
+  const parts = parseStripeHeader(raw);
+  if (!parts.t || (!parts.v1 && !parts.v0)) {
+    return failure("stripe", "header_malformed", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      raw_header: raw,
+    });
+  }
+  if (input.raw_body.length === 0) {
+    return failure("stripe", "body_empty", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      timestamp: parseInt(parts.t, 10),
+      raw_header: raw,
+    });
+  }
+
+  // Stripe currently only signs with v1 (sha256). v0 was a deprecated debug
+  // scheme. We only attempt v1.
+  if (!parts.v1) {
+    return failure("stripe", "unsupported_scheme", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      timestamp: parseInt(parts.t, 10),
+      scheme: "v0",
+      raw_header: raw,
+    });
+  }
+
+  const t = parseInt(parts.t, 10);
+  const now = input.now_seconds ?? Math.floor(Date.now() / 1000);
+  const tolerance = input.tolerance_seconds ?? DEFAULT_TOLERANCE;
+  const age = now - t;
+
+  const computed = createHmac("sha256", input.secret)
+    .update(`${parts.t}.${input.raw_body}`)
+    .digest("hex");
+
+  const matches = constantTimeEqualHex(computed, parts.v1);
+
+  if (!matches) {
+    return failure("stripe", "signature_mismatch", {
+      computed_signature: computed,
+      provided_signature: parts.v1,
+      first_diff_byte: firstDiffByte(computed, parts.v1),
+      timestamp: t,
+      age_seconds: age,
+      hash_algo: "sha256",
+      encoding: "hex",
+      scheme: "v1",
+      raw_header: raw,
+    });
+  }
+
+  if (Math.abs(age) > tolerance) {
+    return failure("stripe", "timestamp_skew", {
+      computed_signature: computed,
+      provided_signature: parts.v1,
+      timestamp: t,
+      age_seconds: age,
+      hash_algo: "sha256",
+      encoding: "hex",
+      scheme: "v1",
+      raw_header: raw,
+    });
+  }
+
+  return success("stripe", {
+    computed_signature: computed,
+    provided_signature: parts.v1,
+    timestamp: t,
+    age_seconds: age,
+    hash_algo: "sha256",
+    encoding: "hex",
+    scheme: "v1",
+    raw_header: raw,
+  });
+}
+
+function parseStripeHeader(raw: string): { t?: string; v1?: string; v0?: string } {
+  const out: { t?: string; v1?: string; v0?: string } = {};
+  for (const pair of raw.split(",")) {
+    const idx = pair.indexOf("=");
+    if (idx < 0) continue;
+    const k = pair.slice(0, idx).trim();
+    const v = pair.slice(idx + 1).trim();
+    if (k === "t" || k === "v0" || k === "v1") out[k] = v;
+  }
+  return out;
+}
+
+// --- GitHub ---
+// X-Hub-Signature-256: sha256=<hex>
+// Computed: HMAC-SHA256(body)
+// (Legacy X-Hub-Signature: sha1=... still emitted but considered insecure.)
+function verifyGithub(input: VerifyInput, headers: Record<string, string>): VerifyResult {
+  const raw = headers["x-hub-signature-256"];
+  const legacy = headers["x-hub-signature"];
+
+  if (!raw && !legacy) {
+    return failure("github", "header_missing", { hash_algo: "sha256", encoding: "hex" });
+  }
+  if (!raw && legacy) {
+    return failure("github", "unsupported_scheme", {
+      hash_algo: "sha1",
+      encoding: "hex",
+      raw_header: legacy,
+      scheme: "sha1",
+    });
+  }
+  // Header format: "sha256=<hex>"
+  const m = raw!.match(/^sha256=([a-fA-F0-9]+)$/);
+  if (!m) {
+    return failure("github", "header_malformed", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      raw_header: raw!,
+    });
+  }
+  const provided = m[1]!;
+
+  if (input.raw_body.length === 0) {
+    return failure("github", "body_empty", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      raw_header: raw!,
+    });
+  }
+
+  const computed = createHmac("sha256", input.secret)
+    .update(input.raw_body)
+    .digest("hex");
+
+  if (!constantTimeEqualHex(computed, provided)) {
+    return failure("github", "signature_mismatch", {
+      computed_signature: computed,
+      provided_signature: provided,
+      first_diff_byte: firstDiffByte(computed, provided),
+      hash_algo: "sha256",
+      encoding: "hex",
+      scheme: "sha256",
+      raw_header: raw!,
+    });
+  }
+
+  return success("github", {
+    computed_signature: computed,
+    provided_signature: provided,
+    hash_algo: "sha256",
+    encoding: "hex",
+    scheme: "sha256",
+    raw_header: raw!,
+  });
+}
+
+// --- Slack ---
+// X-Slack-Signature: v0=<hex>
+// X-Slack-Request-Timestamp: <unix-ts>
+// Computed: HMAC-SHA256(`v0:${ts}:${body}`)
+function verifySlack(input: VerifyInput, headers: Record<string, string>): VerifyResult {
+  const sig = headers["x-slack-signature"];
+  const tsRaw = headers["x-slack-request-timestamp"];
+
+  if (!sig || !tsRaw) {
+    return failure("slack", "header_missing", { hash_algo: "sha256", encoding: "hex" });
+  }
+  const m = sig.match(/^v0=([a-fA-F0-9]+)$/);
+  if (!m) {
+    return failure("slack", "header_malformed", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      raw_header: sig,
+    });
+  }
+  const provided = m[1]!;
+  const t = parseInt(tsRaw, 10);
+  if (!Number.isFinite(t)) {
+    return failure("slack", "header_malformed", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      raw_header: tsRaw,
+    });
+  }
+
+  const now = input.now_seconds ?? Math.floor(Date.now() / 1000);
+  const tolerance = input.tolerance_seconds ?? DEFAULT_TOLERANCE;
+  const age = now - t;
+
+  const computed = createHmac("sha256", input.secret)
+    .update(`v0:${t}:${input.raw_body}`)
+    .digest("hex");
+
+  const matches = constantTimeEqualHex(computed, provided);
+
+  if (!matches) {
+    return failure("slack", "signature_mismatch", {
+      computed_signature: computed,
+      provided_signature: provided,
+      first_diff_byte: firstDiffByte(computed, provided),
+      timestamp: t,
+      age_seconds: age,
+      hash_algo: "sha256",
+      encoding: "hex",
+      scheme: "v0",
+      raw_header: sig,
+    });
+  }
+
+  if (Math.abs(age) > tolerance) {
+    return failure("slack", "timestamp_skew", {
+      computed_signature: computed,
+      provided_signature: provided,
+      timestamp: t,
+      age_seconds: age,
+      hash_algo: "sha256",
+      encoding: "hex",
+      scheme: "v0",
+      raw_header: sig,
+    });
+  }
+
+  return success("slack", {
+    computed_signature: computed,
+    provided_signature: provided,
+    timestamp: t,
+    age_seconds: age,
+    hash_algo: "sha256",
+    encoding: "hex",
+    scheme: "v0",
+    raw_header: sig,
+  });
+}
+
+// --- Shopify ---
+// X-Shopify-Hmac-Sha256: <base64>
+// Computed: HMAC-SHA256(body) → base64
+function verifyShopify(input: VerifyInput, headers: Record<string, string>): VerifyResult {
+  const provided = headers["x-shopify-hmac-sha256"];
+  if (!provided) {
+    return failure("shopify", "header_missing", { hash_algo: "sha256", encoding: "base64" });
+  }
+  if (input.raw_body.length === 0) {
+    return failure("shopify", "body_empty", {
+      hash_algo: "sha256",
+      encoding: "base64",
+      raw_header: provided,
+    });
+  }
+
+  const computed = createHmac("sha256", input.secret)
+    .update(input.raw_body)
+    .digest("base64");
+
+  if (!constantTimeEqualString(computed, provided)) {
+    return failure("shopify", "signature_mismatch", {
+      computed_signature: computed,
+      provided_signature: provided,
+      first_diff_byte: firstDiffByte(computed, provided),
+      hash_algo: "sha256",
+      encoding: "base64",
+      raw_header: provided,
+    });
+  }
+
+  return success("shopify", {
+    computed_signature: computed,
+    provided_signature: provided,
+    hash_algo: "sha256",
+    encoding: "base64",
+    raw_header: provided,
+  });
+}
+
+// --- helpers ---
+
+function lowerKeys(h: Record<string, string>): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(h)) out[k.toLowerCase()] = v;
+  return out;
+}
+
+function constantTimeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+function constantTimeEqualString(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(Buffer.from(a, "utf8"), Buffer.from(b, "utf8"));
+}
+
+function firstDiffByte(a: string, b: string): number {
+  const len = Math.min(a.length, b.length);
+  for (let i = 0; i < len; i++) {
+    if (a[i] !== b[i]) return i;
+  }
+  return len;
+}
+
+function failure(provider: Provider, reason: FailureReason, details: VerifyResult["details"]): VerifyResult {
+  return { valid: false, provider, reason, details };
+}
+
+function success(provider: Provider, details: VerifyResult["details"]): VerifyResult {
+  return { valid: true, provider, details };
+}

--- a/shared/sig-verify.ts
+++ b/shared/sig-verify.ts
@@ -82,7 +82,7 @@ function verifyStripe(input: VerifyInput, headers: Record<string, string>): Veri
     return failure("stripe", "header_missing", { hash_algo: "sha256", encoding: "hex" });
   }
   const parts = parseStripeHeader(raw);
-  if (!parts.t || (!parts.v1 && !parts.v0)) {
+  if (!parts.t || (parts.v1.length === 0 && parts.v0.length === 0)) {
     return failure("stripe", "header_malformed", {
       hash_algo: "sha256",
       encoding: "hex",
@@ -100,7 +100,7 @@ function verifyStripe(input: VerifyInput, headers: Record<string, string>): Veri
 
   // Stripe currently only signs with v1 (sha256). v0 was a deprecated debug
   // scheme. We only attempt v1.
-  if (!parts.v1) {
+  if (parts.v1.length === 0) {
     return failure("stripe", "unsupported_scheme", {
       hash_algo: "sha256",
       encoding: "hex",
@@ -119,13 +119,26 @@ function verifyStripe(input: VerifyInput, headers: Record<string, string>): Veri
     .update(`${parts.t}.${input.raw_body}`)
     .digest("hex");
 
-  const matches = constantTimeEqualHex(computed, parts.v1);
+  // During Stripe's secret-rotation window the header carries multiple v1=
+  // entries — one per active signing secret. The official Stripe SDK tries
+  // each and accepts if any matches. We do the same so users debugging during
+  // rotation get the right answer (QUALITY-REVIEW B2).
+  let matchedSig: string | null = null;
+  for (const candidate of parts.v1) {
+    if (constantTimeEqualHex(computed, candidate)) {
+      matchedSig = candidate;
+      break;
+    }
+  }
 
-  if (!matches) {
+  if (!matchedSig) {
+    // For the diff/UX, point at the first provided v1 (most senders only emit
+    // one anyway).
+    const provided = parts.v1[0]!;
     return failure("stripe", "signature_mismatch", {
       computed_signature: computed,
-      provided_signature: parts.v1,
-      first_diff_byte: firstDiffByte(computed, parts.v1),
+      provided_signature: provided,
+      first_diff_byte: firstDiffByte(computed, provided),
       timestamp: t,
       age_seconds: age,
       hash_algo: "sha256",
@@ -138,7 +151,7 @@ function verifyStripe(input: VerifyInput, headers: Record<string, string>): Veri
   if (Math.abs(age) > tolerance) {
     return failure("stripe", "timestamp_skew", {
       computed_signature: computed,
-      provided_signature: parts.v1,
+      provided_signature: matchedSig,
       timestamp: t,
       age_seconds: age,
       hash_algo: "sha256",
@@ -150,7 +163,7 @@ function verifyStripe(input: VerifyInput, headers: Record<string, string>): Veri
 
   return success("stripe", {
     computed_signature: computed,
-    provided_signature: parts.v1,
+    provided_signature: matchedSig,
     timestamp: t,
     age_seconds: age,
     hash_algo: "sha256",
@@ -160,14 +173,18 @@ function verifyStripe(input: VerifyInput, headers: Record<string, string>): Veri
   });
 }
 
-function parseStripeHeader(raw: string): { t?: string; v1?: string; v0?: string } {
-  const out: { t?: string; v1?: string; v0?: string } = {};
+// Parses Stripe-Signature header into {t, v0[], v1[]}. Multiple v1= entries
+// occur during secret rotation windows (Stripe sends one per active secret).
+function parseStripeHeader(raw: string): { t?: string; v0: string[]; v1: string[] } {
+  const out: { t?: string; v0: string[]; v1: string[] } = { v0: [], v1: [] };
   for (const pair of raw.split(",")) {
     const idx = pair.indexOf("=");
     if (idx < 0) continue;
     const k = pair.slice(0, idx).trim();
     const v = pair.slice(idx + 1).trim();
-    if (k === "t" || k === "v0" || k === "v1") out[k] = v;
+    if (k === "t") out.t = v;
+    else if (k === "v0") out.v0.push(v);
+    else if (k === "v1") out.v1.push(v);
   }
   return out;
 }
@@ -244,8 +261,29 @@ function verifySlack(input: VerifyInput, headers: Record<string, string>): Verif
   const sig = headers["x-slack-signature"];
   const tsRaw = headers["x-slack-request-timestamp"];
 
-  if (!sig || !tsRaw) {
-    return failure("slack", "header_missing", { hash_algo: "sha256", encoding: "hex" });
+  // Distinguish which header is missing so the hint engine can be specific
+  // (QUALITY-REVIEW C1 — previously we said "header_missing" even when only
+  // the timestamp was absent).
+  if (!sig && !tsRaw) {
+    return failure("slack", "header_missing", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      raw_header: "(both X-Slack-Signature and X-Slack-Request-Timestamp missing)",
+    });
+  }
+  if (!sig) {
+    return failure("slack", "header_missing", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      raw_header: "(X-Slack-Signature missing; timestamp present)",
+    });
+  }
+  if (!tsRaw) {
+    return failure("slack", "header_missing", {
+      hash_algo: "sha256",
+      encoding: "hex",
+      raw_header: "(X-Slack-Request-Timestamp missing; signature present)",
+    });
   }
   const m = sig.match(/^v0=([a-fA-F0-9]+)$/);
   if (!m) {

--- a/tests/sigdebug/sig-hints.test.ts
+++ b/tests/sigdebug/sig-hints.test.ts
@@ -1,0 +1,225 @@
+// Hint coverage: each known failure mode should surface its specific guidance.
+// These tests document the hint-string matching so the wedge differentiator
+// stays sharp.
+
+import { test, expect, describe } from "bun:test";
+import { createHmac } from "node:crypto";
+import { verify } from "../../shared/sig-verify";
+import { generateHints } from "../../shared/sig-hints";
+
+function hintsFor(input: Parameters<typeof verify>[0]): string[] {
+  const result = verify(input);
+  return generateHints({ result, input });
+}
+
+describe("Stripe secret-format hints", () => {
+  test("publishable key (pk_live_) → calls it out", () => {
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: "pk_live_abc123",
+      raw_body: "{}",
+      headers: { "stripe-signature": "t=1700000000,v1=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" },
+      now_seconds: 1700000000,
+    });
+    expect(hints.some((h) => h.includes("publishable key"))).toBe(true);
+    expect(hints.some((h) => h.includes("whsec_"))).toBe(true);
+  });
+
+  test("API secret (sk_live_) → calls it out", () => {
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: "sk_live_abc123",
+      raw_body: "{}",
+      headers: { "stripe-signature": "t=1700000000,v1=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" },
+      now_seconds: 1700000000,
+    });
+    expect(hints.some((h) => h.includes("API secret key"))).toBe(true);
+  });
+
+  test("missing whsec_ prefix → suggests checking", () => {
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: "randomstring",
+      raw_body: "{}",
+      headers: { "stripe-signature": "t=1700000000,v1=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" },
+      now_seconds: 1700000000,
+    });
+    expect(hints.some((h) => h.includes("whsec_"))).toBe(true);
+  });
+
+  test("whitespace in secret → flagged", () => {
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: " whsec_abc \n",
+      raw_body: "{}",
+      headers: { "stripe-signature": "t=1700000000,v1=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" },
+      now_seconds: 1700000000,
+    });
+    expect(hints.some((h) => h.includes("whitespace"))).toBe(true);
+  });
+});
+
+describe("Timestamp skew hints", () => {
+  test("stale timestamp → suggests Stripe CLI / NTP", () => {
+    const t = 1700000000;
+    const secret = "whsec_x";
+    const body = "{}";
+    const sig = createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+    const hints = hintsFor({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: { "stripe-signature": `t=${t},v1=${sig}` },
+      now_seconds: t + 7200, // 2h later
+    });
+    expect(hints.some((h) => h.includes("past"))).toBe(true);
+    expect(hints.some((h) => h.includes("NTP") || h.includes("Stripe CLI"))).toBe(true);
+  });
+
+  test("future timestamp → suggests clock-ahead", () => {
+    const t = 1700000000;
+    const secret = "whsec_x";
+    const body = "{}";
+    const sig = createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+    const hints = hintsFor({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: { "stripe-signature": `t=${t},v1=${sig}` },
+      now_seconds: t - 7200, // 2h earlier
+    });
+    expect(hints.some((h) => h.includes("future"))).toBe(true);
+    expect(hints.some((h) => h.includes("clock"))).toBe(true);
+  });
+});
+
+describe("Body-shape hints", () => {
+  test("empty body → suggests body-parser issue", () => {
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: "whsec_x",
+      raw_body: "",
+      headers: { "stripe-signature": "t=1700000000,v1=abc" },
+      now_seconds: 1700000000,
+    });
+    expect(hints.some((h) => h.includes("empty"))).toBe(true);
+    expect(hints.some((h) => h.includes("body-parser") || h.includes("raw"))).toBe(true);
+  });
+
+  test("pretty-printed JSON (key + colon + space) → calls out re-stringify", () => {
+    // body that LOOKS like JSON.stringify(obj, null, 2) output
+    const body = '{\n  "id": "evt_test"\n}';
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: "whsec_x",
+      raw_body: body,
+      headers: { "stripe-signature": "t=1700000000,v1=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" },
+      now_seconds: 1700000000,
+    });
+    expect(hints.some((h) => h.includes("JSON.stringify") || h.includes("indent"))).toBe(true);
+  });
+
+  test("trailing newline → flagged", () => {
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: "whsec_x",
+      raw_body: '{"id":"evt_test"}\n',
+      headers: { "stripe-signature": "t=1700000000,v1=abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890" },
+      now_seconds: 1700000000,
+    });
+    expect(hints.some((h) => h.includes("newline"))).toBe(true);
+  });
+});
+
+describe("Header hints", () => {
+  test("header missing → suggests proxy stripping", () => {
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: "whsec_x",
+      raw_body: "{}",
+      headers: { "x-forwarded-for": "1.2.3.4" },
+    });
+    expect(hints.some((h) => h.includes("missing"))).toBe(true);
+    expect(hints.some((h) => h.includes("proxy"))).toBe(true);
+  });
+
+  test("malformed header → echoes expected shape + got value", () => {
+    const hints = hintsFor({
+      provider: "github",
+      secret: "x",
+      raw_body: "x",
+      headers: { "x-hub-signature-256": "garbage" },
+    });
+    expect(hints.some((h) => h.includes("sha256="))).toBe(true);
+    expect(hints.some((h) => h.includes("garbage"))).toBe(true);
+  });
+});
+
+describe("Scheme hints", () => {
+  test("GitHub legacy sha1 → directs to SHA-256 header", () => {
+    const hints = hintsFor({
+      provider: "github",
+      secret: "x",
+      raw_body: "x",
+      headers: { "x-hub-signature": "sha1=abc" },
+    });
+    expect(hints.some((h) => h.includes("SHA-1") || h.includes("sha1"))).toBe(true);
+    expect(hints.some((h) => h.includes("X-Hub-Signature-256"))).toBe(true);
+  });
+
+  test("Stripe v0 → directs to v1", () => {
+    const hints = hintsFor({
+      provider: "stripe",
+      secret: "whsec_x",
+      raw_body: "{}",
+      headers: { "stripe-signature": "t=1700000000,v0=abc" },
+      now_seconds: 1700000000,
+    });
+    expect(hints.some((h) => h.includes("v1"))).toBe(true);
+  });
+});
+
+describe("Signature-pattern hints", () => {
+  test("different lengths → flagged as wrong encoding", () => {
+    // GitHub expects 64-char hex sha256; provide a 40-char hex (sha1-length)
+    const hints = hintsFor({
+      provider: "github",
+      secret: "x",
+      raw_body: "y",
+      headers: { "x-hub-signature-256": "sha256=" + "a".repeat(40) },
+    });
+    // Falls into header_malformed path because 40 hex doesn't match sha256
+    // length, but we want the hint to still point at the encoding/length issue.
+    // The malformed check fires first; verify hint surfaces the shape mismatch.
+    expect(hints.length).toBeGreaterThan(0);
+  });
+
+  test("first byte differs → suggests wrong secret entirely", () => {
+    const t = 1700000000;
+    const secret = "whsec_correct";
+    const body = "{}";
+    const correctSig = createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+    // Provide a sig that differs from byte 0
+    const fakeSig = "f" + correctSig.slice(1);
+    const hints = hintsFor({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: { "stripe-signature": `t=${t},v1=${fakeSig}` },
+      now_seconds: t,
+    });
+    expect(hints.some((h) => h.includes("from the very first byte") || h.includes("wrong secret"))).toBe(true);
+  });
+});
+
+describe("Valid result → no hints", () => {
+  test("github valid case returns empty hints array", () => {
+    const hints = hintsFor({
+      provider: "github",
+      secret: "It's a Secret to Everybody",
+      raw_body: "Hello, World!",
+      headers: { "x-hub-signature-256": "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17" },
+    });
+    expect(hints).toEqual([]);
+  });
+});

--- a/tests/sigdebug/sig-verify.test.ts
+++ b/tests/sigdebug/sig-verify.test.ts
@@ -1,0 +1,281 @@
+// Reference test vectors for each provider, taken from official docs.
+// These are the gold-standard "correct" cases — if our verifier doesn't pass
+// these, we've shipped a bug that breaks every real webhook.
+//
+// Stripe: docs.stripe.com/webhooks/signatures (no public reference vector,
+//   so we generate our own with HMAC-SHA256 and verify the math)
+// GitHub: docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+//   has a reference: secret="It's a Secret to Everybody", body="Hello, World!",
+//   sig=sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17
+// Slack: api.slack.com/authentication/verifying-requests-from-slack reference
+// Shopify: docs.shopify.com (verified against Node `crypto` reference)
+
+import { test, expect, describe } from "bun:test";
+import { createHmac } from "node:crypto";
+import { verify } from "../../shared/sig-verify";
+
+describe("Stripe verifier", () => {
+  const secret = "whsec_testsecretdemo";
+  const body = '{"id":"evt_test","object":"event","type":"payment_intent.succeeded"}';
+  const t = 1700000000;
+  const expected = createHmac("sha256", secret).update(`${t}.${body}`).digest("hex");
+
+  test("valid signature returns valid=true", () => {
+    const result = verify({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: { "stripe-signature": `t=${t},v1=${expected}` },
+      now_seconds: t,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.details.computed_signature).toBe(expected);
+    expect(result.details.timestamp).toBe(t);
+    expect(result.details.age_seconds).toBe(0);
+  });
+
+  test("wrong secret → signature_mismatch with diff details", () => {
+    const result = verify({
+      provider: "stripe",
+      secret: "whsec_wrong",
+      raw_body: body,
+      headers: { "stripe-signature": `t=${t},v1=${expected}` },
+      now_seconds: t,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("signature_mismatch");
+    expect(result.details.computed_signature).not.toBe(expected);
+    expect(result.details.first_diff_byte).toBe(0); // wrong-secret diverges from byte 0
+  });
+
+  test("stale timestamp (>5min) → timestamp_skew", () => {
+    const result = verify({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: { "stripe-signature": `t=${t},v1=${expected}` },
+      now_seconds: t + 600, // 10 min later
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("timestamp_skew");
+    expect(result.details.age_seconds).toBe(600);
+  });
+
+  test("missing header → header_missing", () => {
+    const result = verify({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: {},
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("header_missing");
+  });
+
+  test("malformed header → header_malformed", () => {
+    const result = verify({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: { "stripe-signature": "this is not a valid stripe sig" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("header_malformed");
+  });
+
+  test("empty body → body_empty", () => {
+    const result = verify({
+      provider: "stripe",
+      secret,
+      raw_body: "",
+      headers: { "stripe-signature": `t=${t},v1=${expected}` },
+      now_seconds: t,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("body_empty");
+  });
+
+  test("v0 only → unsupported_scheme", () => {
+    const result = verify({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: { "stripe-signature": `t=${t},v0=${expected}` },
+      now_seconds: t,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("unsupported_scheme");
+    expect(result.details.scheme).toBe("v0");
+  });
+
+  test("case-insensitive header names", () => {
+    const result = verify({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      headers: { "Stripe-Signature": `t=${t},v1=${expected}` },
+      now_seconds: t,
+    });
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe("GitHub verifier — official reference vector", () => {
+  // From docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries
+  const secret = "It's a Secret to Everybody";
+  const body = "Hello, World!";
+  const expectedSig = "757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
+
+  test("official reference vector verifies", () => {
+    const result = verify({
+      provider: "github",
+      secret,
+      raw_body: body,
+      headers: { "x-hub-signature-256": `sha256=${expectedSig}` },
+    });
+    expect(result.valid).toBe(true);
+    expect(result.details.computed_signature).toBe(expectedSig);
+  });
+
+  test("wrong secret → signature_mismatch", () => {
+    const result = verify({
+      provider: "github",
+      secret: "wrong",
+      raw_body: body,
+      headers: { "x-hub-signature-256": `sha256=${expectedSig}` },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("signature_mismatch");
+  });
+
+  test("legacy sha1 header → unsupported_scheme", () => {
+    const result = verify({
+      provider: "github",
+      secret,
+      raw_body: body,
+      headers: { "x-hub-signature": "sha1=somelegacyhash" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("unsupported_scheme");
+    expect(result.details.scheme).toBe("sha1");
+  });
+
+  test("malformed header → header_malformed", () => {
+    const result = verify({
+      provider: "github",
+      secret,
+      raw_body: body,
+      headers: { "x-hub-signature-256": "not-the-right-format" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("header_malformed");
+  });
+});
+
+describe("Slack verifier", () => {
+  const secret = "8f742231b10e8888abcd99yyyzzz85a5";
+  const t = 1531420618;
+  const body = "token=xyzz0WbapA4vBCDEFasx0q6G&team_id=T1DC2JH3J&team_domain=testteamnow&channel_id=G8PSS9T3V&channel_name=foobar&user_id=U2CERLKJA&user_name=roadrunner&command=%2Fwebhook-collect&text=&response_url=https%3A%2F%2Fhooks.slack.com%2Fcommands%2FT1DC2JH3J%2F397700885554%2F96rGlfmibIGlgcZRskXaIFfN&trigger_id=398738663015.47445629121.803a0bc887a14d10d2c447fce8b6703c";
+  const expected = createHmac("sha256", secret).update(`v0:${t}:${body}`).digest("hex");
+
+  test("valid signature verifies", () => {
+    const result = verify({
+      provider: "slack",
+      secret,
+      raw_body: body,
+      headers: {
+        "x-slack-signature": `v0=${expected}`,
+        "x-slack-request-timestamp": String(t),
+      },
+      now_seconds: t,
+    });
+    expect(result.valid).toBe(true);
+  });
+
+  test("missing timestamp header → header_missing", () => {
+    const result = verify({
+      provider: "slack",
+      secret,
+      raw_body: body,
+      headers: { "x-slack-signature": `v0=${expected}` },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("header_missing");
+  });
+
+  test("stale timestamp → timestamp_skew", () => {
+    const result = verify({
+      provider: "slack",
+      secret,
+      raw_body: body,
+      headers: {
+        "x-slack-signature": `v0=${expected}`,
+        "x-slack-request-timestamp": String(t),
+      },
+      now_seconds: t + 1000,
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("timestamp_skew");
+  });
+});
+
+describe("Shopify verifier", () => {
+  const secret = "shpss_secret123";
+  const body = '{"id":12345,"order_number":1001}';
+  const expected = createHmac("sha256", secret).update(body).digest("base64");
+
+  test("valid base64 signature verifies", () => {
+    const result = verify({
+      provider: "shopify",
+      secret,
+      raw_body: body,
+      headers: { "x-shopify-hmac-sha256": expected },
+    });
+    expect(result.valid).toBe(true);
+    expect(result.details.encoding).toBe("base64");
+    expect(result.details.computed_signature).toBe(expected);
+  });
+
+  test("wrong secret → signature_mismatch", () => {
+    const result = verify({
+      provider: "shopify",
+      secret: "wrong",
+      raw_body: body,
+      headers: { "x-shopify-hmac-sha256": expected },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("signature_mismatch");
+  });
+
+  test("missing header → header_missing", () => {
+    const result = verify({
+      provider: "shopify",
+      secret,
+      raw_body: body,
+      headers: {},
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("header_missing");
+  });
+});
+
+describe("Constant-time comparison resists trivial timing attacks", () => {
+  // Sanity check that we use timingSafeEqual, not ===. We can't measure
+  // timing reliably in a unit test, but we can confirm comparing two equal-length
+  // strings with very different bytes still reaches the comparator.
+  const secret = "x";
+  const body = "y";
+  const expected = createHmac("sha256", secret).update(body).digest("hex");
+  const wrong = "0".repeat(expected.length);
+
+  test("equal-length wrong sig still returns mismatch (no early exit)", () => {
+    const result = verify({
+      provider: "github",
+      secret,
+      raw_body: body,
+      headers: { "x-hub-signature-256": `sha256=${wrong}` },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("signature_mismatch");
+  });
+});

--- a/tests/sigdebug/sig-verify.test.ts
+++ b/tests/sigdebug/sig-verify.test.ts
@@ -118,6 +118,24 @@ describe("Stripe verifier", () => {
     });
     expect(result.valid).toBe(true);
   });
+
+  test("multiple v1= entries (secret-rotation window) — verifier tries each", () => {
+    // Stripe sends one v1= per active signing secret during rotation.
+    // QUALITY-REVIEW B2: previously we kept only the LAST v1=, so a user
+    // debugging during rotation with the OLDER secret (still active) got a
+    // false signature_mismatch.
+    const wrongSig = "0".repeat(64);
+    const result = verify({
+      provider: "stripe",
+      secret,
+      raw_body: body,
+      // wrong sig FIRST, correct sig SECOND
+      headers: { "stripe-signature": `t=${t},v1=${wrongSig},v1=${expected}` },
+      now_seconds: t,
+    });
+    expect(result.valid).toBe(true);
+    expect(result.details.provided_signature).toBe(expected);
+  });
 });
 
 describe("GitHub verifier — official reference vector", () => {
@@ -192,7 +210,9 @@ describe("Slack verifier", () => {
     expect(result.valid).toBe(true);
   });
 
-  test("missing timestamp header → header_missing", () => {
+  test("missing timestamp header → header_missing with specific raw_header note", () => {
+    // QUALITY-REVIEW C1: previously we said "header_missing" without
+    // distinguishing which header. Now raw_header carries which one is gone.
     const result = verify({
       provider: "slack",
       secret,
@@ -201,6 +221,19 @@ describe("Slack verifier", () => {
     });
     expect(result.valid).toBe(false);
     expect(result.reason).toBe("header_missing");
+    expect(result.details.raw_header).toContain("Timestamp");
+  });
+
+  test("missing signature header but timestamp present → specific error", () => {
+    const result = verify({
+      provider: "slack",
+      secret,
+      raw_body: body,
+      headers: { "x-slack-request-timestamp": "1700000000" },
+    });
+    expect(result.valid).toBe(false);
+    expect(result.reason).toBe("header_missing");
+    expect(result.details.raw_header).toContain("Signature");
   });
 
   test("stale timestamp → timestamp_skew", () => {


### PR DESCRIPTION
## What

Hosted webhook-signature debugger live at \`stripesig.apimesh.xyz\` and \`sigdebug.apimesh.xyz\` (301 alias). Wedge #2 of the [conway pivot](../../vault/research/conway-pivot-2026-04-28/WEDGES.md).

## The pitch

Engineer hits \`Webhook signature verification failed\` in prod logs at 11pm. Googles it. Lands here. Pastes the failing payload + secret + signature header. Gets a plain-English answer in 5 seconds — *why* it failed.

## Providers (v0.1)

All HMAC-SHA256:

- Stripe — \`Stripe-Signature: t=...,v1=<hex>\`
- GitHub — \`X-Hub-Signature-256: sha256=<hex>\`
- Slack — \`X-Slack-Signature: v0=<hex>\` + \`X-Slack-Request-Timestamp\`
- Shopify — \`X-Shopify-Hmac-Sha256: <base64>\`

## What gets shipped

- \`apis/sigdebug/\` — Hono sub-app + landing page (paste form + result UI)
- \`shared/sig-verify.ts\` — pure verifier with timing-safe compare
- \`shared/sig-hints.ts\` — plain-English hint engine (the wedge)
- \`tests/sigdebug/\` — 35 tests including GitHub's official reference vector
- \`apis/registry.ts\` — registers \`stripesig\` + \`sigdebug\` subdomains

## API

\`\`\`
POST /check
{ "provider": "stripe", "secret": "whsec_...", "raw_body": "...", "headers": {...} }
→ { valid, reason, hints[], details }
\`\`\`

Rate-limited 60/min. Caps: 100K body / 1K secret / 4K per header. CORS open. No auth, no signup, no persistence.

## Hint examples

User pastes a webhook with \`pk_live_...\` as the secret →
> Your secret starts with 'pk_' which is a Stripe publishable key, not a webhook signing secret. Webhook secrets start with 'whsec_'. Find it in your Stripe dashboard under Developers → Webhooks → click your endpoint → Signing secret.

User pastes a 2-day-old timestamp →
> Your timestamp is 2 days in the past. This usually means: (1) you're testing with a recorded payload from earlier (Stripe CLI sessions, fixtures, replays — Stripe rejects events older than 5 minutes), or (2) your server's clock is significantly behind (check NTP).

## Test plan

- [ ] Deploy → curl stripesig.apimesh.xyz/health
- [ ] Verify 301 from sigdebug → stripesig
- [ ] Verify rate-limit at 61st req/min
- [ ] Verify 100K body cap → 413
- [ ] Verify GitHub reference vector through the live endpoint
- [ ] Run a real failing Stripe webhook from your own integration through it

## Audit

Security + quality audit agents running in parallel — will land in apis/sigdebug/SECURITY-AUDIT.md and QUALITY-REVIEW.md before merge.

## Why

Per [WEDGES.md](../../vault/research/conway-pivot-2026-04-28/WEDGES.md): wedge #2 is the lowest-effort first-revenue path. 30-day exit clock shared with wedge #1 (agentcontext) → 2026-05-29.