### PR TITLE
feat: email capture + referer/UTM logging on both wedges

### DIFF
--- a/apis/agentcontext/index.ts
+++ b/apis/agentcontext/index.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { rateLimit } from "../../shared/rate-limit";
 import { apiLogger } from "../../shared/logger";
+import { signupNotifyHandler } from "../../shared/signup-notify";
 
 import {
   parseAgentsMd,
@@ -54,12 +55,25 @@ app.use("*", async (c, next) => {
   return next();
 });
 
-app.use("*", rateLimit("agentcontext", 60, 60_000));
+// Path-scoped limits run BEFORE the wildcard so that hitting one of these
+// limits doesn't also burn the wildcard's 60/min quota — and so that
+// /signup-notify cannot ride the wildcard's larger budget if either rule's
+// counter happens to be in a different state. (SECURITY-AUDIT B1.)
 app.use("/normalize", rateLimit("agentcontext-normalize", 30, 60_000));
+app.use("/signup-notify", rateLimit("agentcontext-signup", 5, 60_000));
+app.use("*", rateLimit("agentcontext", 60, 60_000));
 app.use("*", apiLogger(API_NAME, 0));
 
 // Landing page (single HTML, embedded inline form for /normalize).
 app.get("/", (c) => c.html(LANDING_HTML));
+
+app.post("/signup-notify", signupNotifyHandler({
+  allowed: [{ source: "agentcontext", interest: "github-app" }],
+  allowedOrigins: [
+    "https://agentsmd.apimesh.xyz",
+    "https://agentcontext.apimesh.xyz",
+  ],
+}));
 
 // Free conversion endpoint. Accepts source content + format, returns rendered file map.
 // No auth — rate-limited only. Cap input size to prevent abuse.

--- a/apis/agentcontext/landing.html
+++ b/apis/agentcontext/landing.html
@@ -175,6 +175,15 @@ npx @mbeato/agentcontext sync --write --shims claude,cursor,cline
 # Explicit one-direction conversion
 npx @mbeato/agentcontext convert --from cursor-mdc --to agents-md --in .cursor/rules/style.mdc</code></pre>
 
+  <h2>Notify me</h2>
+  <p class="muted">A GitHub App version is on the roadmap (auto-sync rules across all your repos). Drop your email if you want a heads-up when it lands.</p>
+  <form id="notify-form" class="row" style="margin-bottom: 8px;">
+    <input id="notify-email" type="email" required placeholder="you@company.com"
+      style="flex: 1; min-width: 220px; padding: 8px 12px; font-size: 14px; border: 1px solid #d6d3d1; border-radius: 4px; background: #fff;" />
+    <button id="notify-btn" type="submit">Notify me</button>
+    <span class="muted" id="notify-status"></span>
+  </form>
+
   <footer>
     <p>
       MIT • <a href="https://github.com/mbeato/agentcontext">GitHub</a> •
@@ -191,6 +200,37 @@ npx @mbeato/agentcontext convert --from cursor-mdc --to agents-md --in .cursor/r
     const srcTa = document.getElementById('src');
     const out = document.getElementById('out');
     const status = document.getElementById('status');
+
+    const notifyForm = document.getElementById('notify-form');
+    const notifyEmail = document.getElementById('notify-email');
+    const notifyBtn = document.getElementById('notify-btn');
+    const notifyStatus = document.getElementById('notify-status');
+
+    notifyForm.addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const email = (notifyEmail.value || '').trim();
+      if (!email) return;
+      notifyBtn.disabled = true;
+      notifyStatus.textContent = 'sending...';
+      try {
+        const r = await fetch('/signup-notify', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ email, source: 'agentcontext', interest: 'github-app' }),
+        });
+        const data = await r.json().catch(() => ({}));
+        if (r.ok) {
+          notifyStatus.textContent = data.deduped ? "you're already on the list" : "got it — you're on the list";
+          notifyEmail.value = '';
+        } else {
+          notifyStatus.textContent = data.error || 'failed';
+        }
+      } catch (err) {
+        notifyStatus.textContent = 'failed: ' + err.message;
+      } finally {
+        notifyBtn.disabled = false;
+      }
+    });
 
     btn.addEventListener('click', async () => {
       status.textContent = 'converting...';

--- a/apis/dashboard/dashboard.html
+++ b/apis/dashboard/dashboard.html
@@ -680,6 +680,26 @@
           </tbody>
         </table>
       </div>
+
+      <div class="panel">
+        <div class="panel-header">
+          Signup notifications
+          <span class="meta" id="signup-summary" style="margin-left:12px;font-weight:400"></span>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Time</th>
+              <th>Source</th>
+              <th>Interest</th>
+              <th>Email</th>
+            </tr>
+          </thead>
+          <tbody id="signup-table">
+            <tr><td colspan="4" class="empty-state">No signups yet</td></tr>
+          </tbody>
+        </table>
+      </div>
       </div><!-- /tab-overview -->
 
       <div id="tab-audit" class="tab-content">

--- a/apis/dashboard/dashboard.js
+++ b/apis/dashboard/dashboard.js
@@ -313,6 +313,33 @@ function render(data) {
         '<td>' + (r.paid ? '<span class="badge badge-paid">paid</span>' : '<span class="badge badge-free">free</span>') + '</td></tr>';
     }).join("");
   }
+
+  var sn = data.signup_notifications || { counts: [], recent: [] };
+  var summaryEl = document.getElementById("signup-summary");
+  if (summaryEl) {
+    if (sn.counts && sn.counts.length) {
+      var total = sn.counts.reduce(function(s, x) { return s + (x.count || 0); }, 0);
+      // textContent escapes automatically — don't double-encode via esc().
+      var per = sn.counts.map(function(x) { return x.source + " " + fmtN(x.count); }).join(" · ");
+      summaryEl.textContent = fmtN(total) + " total — " + per;
+    } else {
+      summaryEl.textContent = "0 total";
+    }
+  }
+  var sb = document.getElementById("signup-table");
+  if (sb) {
+    if (!sn.recent || !sn.recent.length) {
+      sb.innerHTML = '<tr><td colspan="4" class="empty-state">No signups yet</td></tr>';
+    } else {
+      sb.innerHTML = sn.recent.slice(0, 20).map(function(r) {
+        return '<tr>' +
+          '<td class="mono dim">' + fmtTime(r.created_at) + '</td>' +
+          '<td class="primary">' + esc(r.source) + '</td>' +
+          '<td class="mono dim">' + esc(r.interest || "") + '</td>' +
+          '<td class="mono">' + esc(r.email) + '</td></tr>';
+      }).join("");
+    }
+  }
 }
 
 // --- API Detail Modal ---

--- a/apis/dashboard/index.ts
+++ b/apis/dashboard/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { bearerAuth } from "hono/bearer-auth";
 import { setCookie, getCookie, deleteCookie } from "hono/cookie";
 import { resolve, join } from "path";
-import db, { getRevenueByApi, getTotalRevenue, getRequestCount, getErrorRate, getApiRevenue, getRecentRequests, getActiveApis, getDailyRevenue, getDailyRequests, getHourlyRequests, getAuditLog, getWalletSummaries, getAllSpendCaps, upsertSpendCap, deleteSpendCap, getWalletSpend, getSpendCap, getApiDetailedStats, getApiRequests, getApiErrors, getApiStatusBreakdown } from "../../shared/db";
+import db, { getRevenueByApi, getTotalRevenue, getRequestCount, getErrorRate, getApiRevenue, getRecentRequests, getActiveApis, getDailyRevenue, getDailyRequests, getHourlyRequests, getAuditLog, getWalletSummaries, getAllSpendCaps, upsertSpendCap, deleteSpendCap, getWalletSpend, getSpendCap, getApiDetailedStats, getApiRequests, getApiErrors, getApiStatusBreakdown, getSignupNotificationCounts, getRecentSignupNotifications } from "../../shared/db";
 import { WALLET_ADDRESS } from "../../shared/x402";
 import { rateLimit } from "../../shared/rate-limit";
 import { hashPassword, verifyPassword, createSession, getSession, deleteSession, deleteUserSessions, refreshSessionExpiry, logAuthEvent } from "../../shared/auth";
@@ -1710,6 +1710,10 @@ app.get("/api/stats", (c) => {
     apis,
     total_requests: totalRequestsRange,
     recent_requests: getRecentRequests(20),
+    signup_notifications: {
+      counts: getSignupNotificationCounts(),
+      recent: getRecentSignupNotifications(undefined, 20),
+    },
     charts: {
       daily_revenue_7d: getDailyRevenue(7),
       daily_revenue_30d: getDailyRevenue(30),

--- a/apis/sigdebug/index.ts
+++ b/apis/sigdebug/index.ts
@@ -4,6 +4,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { rateLimit } from "../../shared/rate-limit";
 import { apiLogger } from "../../shared/logger";
+import { signupNotifyHandler } from "../../shared/signup-notify";
 import { verify, type Provider, type VerifyInput } from "../../shared/sig-verify";
 import { generateHints } from "../../shared/sig-hints";
 
@@ -36,10 +37,22 @@ app.use("*", async (c, next) => {
 // Single rate-limit zone applies to /check + landing alike. The earlier
 // double-registration (one wildcard, one /check-specific) summed to ~120/min
 // effective on /check (SECURITY-AUDIT M1). One zone, one limit.
+// Path-scoped /signup-notify limit runs BEFORE the wildcard so the
+// signup-notify counter is the binding constraint without first burning
+// the wildcard 60/min quota. (SECURITY-AUDIT B1.)
+app.use("/signup-notify", rateLimit("sigdebug-signup", 5, 60_000));
 app.use("*", rateLimit("sigdebug", 60, 60_000));
 app.use("*", apiLogger(API_NAME, 0));
 
 app.get("/", (c) => c.html(LANDING_HTML));
+
+app.post("/signup-notify", signupNotifyHandler({
+  allowed: [{ source: "sigdebug", interest: "paid-tier" }],
+  allowedOrigins: [
+    "https://stripesig.apimesh.xyz",
+    "https://sigdebug.apimesh.xyz",
+  ],
+}));
 
 const SUPPORTED_PROVIDERS: Provider[] = ["stripe", "github", "slack", "shopify"];
 const MAX_BODY_CHARS = 100_000;

--- a/apis/sigdebug/landing.html
+++ b/apis/sigdebug/landing.html
@@ -168,6 +168,15 @@
   <h2>Privacy</h2>
   <p>We don't log your secret or body. Each <code>/check</code> request is processed in-memory and discarded. CORS allows direct browser calls — your secret never leaves your machine if you call the API client-side.</p>
 
+  <h2>Notify me</h2>
+  <p class="muted">A paid tier is on the roadmap (replay attempts, history, more providers, team views). Drop your email if you want a heads-up.</p>
+  <form id="notify-form" style="display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 8px; align-items: center;">
+    <input id="notify-email" type="email" required placeholder="you@company.com"
+      style="flex: 1; min-width: 220px; padding: 9px 12px; font-size: 14px; border: 1px solid #d6d3d1; border-radius: 4px; background: #fff;" />
+    <button id="notify-btn" type="submit">Notify me</button>
+    <span class="muted" id="notify-status"></span>
+  </form>
+
   <footer>
     <p>
       Part of the <a href="https://apimesh.xyz">apimesh.xyz</a> portfolio. MIT-spirited (no published source yet — single endpoint, easy to audit).
@@ -292,6 +301,38 @@
       div.textContent = String(s);
       return div.innerHTML;
     }
+
+    (function setupNotify() {
+      const form = document.getElementById('notify-form');
+      const emailInput = document.getElementById('notify-email');
+      const btn = document.getElementById('notify-btn');
+      const statusEl = document.getElementById('notify-status');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const email = (emailInput.value || '').trim();
+        if (!email) return;
+        btn.disabled = true;
+        statusEl.textContent = 'sending...';
+        try {
+          const r = await fetch('/signup-notify', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ email, source: 'sigdebug', interest: 'paid-tier' })
+          });
+          const data = await r.json().catch(() => ({}));
+          if (r.ok) {
+            statusEl.textContent = data.deduped ? "you're already on the list" : "got it — you're on the list";
+            emailInput.value = '';
+          } else {
+            statusEl.textContent = data.error || 'failed';
+          }
+        } catch (err) {
+          statusEl.textContent = 'failed: ' + err.message;
+        } finally {
+          btn.disabled = false;
+        }
+      });
+    })();
   </script>
 
 </body>

--- a/data/migrations/010_signup_notifications_and_attribution.sql
+++ b/data/migrations/010_signup_notifications_and_attribution.sql
@@ -1,0 +1,25 @@
+-- Migration 010: Email capture + traffic attribution
+-- Two changes:
+--   1. Add referer + UTM columns to requests for traffic-source attribution
+--      (lets us see which cold-email link / X post / SEO term sent the visit).
+--   2. Add signup_notifications table for "notify me when X launches" capture
+--      from wedge landing pages (agentcontext, sigdebug).
+
+ALTER TABLE requests ADD COLUMN referer TEXT DEFAULT NULL;
+ALTER TABLE requests ADD COLUMN utm_source TEXT DEFAULT NULL;
+ALTER TABLE requests ADD COLUMN utm_medium TEXT DEFAULT NULL;
+ALTER TABLE requests ADD COLUMN utm_campaign TEXT DEFAULT NULL;
+
+CREATE TABLE IF NOT EXISTS signup_notifications (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  email TEXT NOT NULL,
+  source TEXT NOT NULL,
+  interest TEXT,
+  ip TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  UNIQUE(email, source)
+);
+
+CREATE INDEX IF NOT EXISTS idx_signup_notifications_source ON signup_notifications(source);
+CREATE INDEX IF NOT EXISTS idx_signup_notifications_created_at ON signup_notifications(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_requests_utm_source ON requests(utm_source);

--- a/scripts/run-migrations.ts
+++ b/scripts/run-migrations.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env bun
+// Runs database migrations idempotently. Safe to re-run.
+// Usage on prod: ssh conway-prod 'cd /opt/conway-agent && DATA_DIR=/opt/conway-agent/data bun scripts/run-migrations.ts'
+//
+// The migration system in shared/migrate.ts tracks applied migrations by
+// name + SHA-256 checksum in the _migrations table, so re-running this
+// script is a no-op once every file has been applied.
+import "../shared/db";
+console.log("✓ migrations applied");

--- a/shared/db.ts
+++ b/shared/db.ts
@@ -33,6 +33,13 @@ migrate(db, join(import.meta.dir, "..", "data", "migrations"));
 
 export default db;
 
+export interface RequestAttribution {
+  referer?: string;
+  utmSource?: string;
+  utmMedium?: string;
+  utmCampaign?: string;
+}
+
 export function logRequest(
   apiName: string,
   endpoint: string,
@@ -45,13 +52,99 @@ export function logRequest(
   payerWallet?: string,
   userId?: string,
   apiKeyId?: string,
-  userAgent?: string
+  userAgent?: string,
+  attribution?: RequestAttribution
 ) {
   db.run(
-    `INSERT INTO requests (api_name, endpoint, method, status_code, response_time_ms, paid, amount_usd, client_ip, payer_wallet, user_id, api_key_id, user_agent)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-    [apiName, endpoint, method, statusCode, responseTimeMs, paid ? 1 : 0, amountUsd, clientIp, payerWallet ?? null, userId ?? null, apiKeyId ?? null, userAgent ?? null]
+    `INSERT INTO requests (api_name, endpoint, method, status_code, response_time_ms, paid, amount_usd, client_ip, payer_wallet, user_id, api_key_id, user_agent, referer, utm_source, utm_medium, utm_campaign)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      apiName, endpoint, method, statusCode, responseTimeMs,
+      paid ? 1 : 0, amountUsd, clientIp,
+      payerWallet ?? null, userId ?? null, apiKeyId ?? null, userAgent ?? null,
+      attribution?.referer ?? null,
+      attribution?.utmSource ?? null,
+      attribution?.utmMedium ?? null,
+      attribution?.utmCampaign ?? null,
+    ]
   );
+}
+
+// --- Signup notifications (email capture from wedge landing pages) ---
+
+export interface SignupNotification {
+  id: number;
+  email: string;
+  source: string;
+  interest: string | null;
+  ip: string | null;
+  created_at: string;
+}
+
+/**
+ * Records a signup-notification request. Idempotent: duplicate (email, source)
+ * pairs are silently dropped via INSERT OR IGNORE. Returns true if a new row
+ * was inserted, false if it was a duplicate.
+ *
+ * Throws SignupTableFullError if the table has reached SIGNUP_MAX_ROWS — see
+ * SECURITY-AUDIT H2 (the table grows forever otherwise; the IPv4-rate-limit
+ * doesn't bound distinct senders).
+ */
+export const SIGNUP_MAX_ROWS = 100_000;
+
+export class SignupTableFullError extends Error {
+  constructor() { super("signup_notifications table is full"); }
+}
+
+export function recordSignupNotification(
+  email: string,
+  source: string,
+  interest: string | null,
+  ip: string | null
+): boolean {
+  const totalRow = db
+    .query(`SELECT COUNT(*) AS cnt FROM signup_notifications`)
+    .get() as { cnt: number };
+  if (totalRow.cnt >= SIGNUP_MAX_ROWS) {
+    throw new SignupTableFullError();
+  }
+  const result = db.run(
+    `INSERT OR IGNORE INTO signup_notifications (email, source, interest, ip)
+     VALUES (?, ?, ?, ?)`,
+    [email, source, interest, ip]
+  );
+  return result.changes > 0;
+}
+
+export function getSignupNotificationCounts(): { source: string; count: number }[] {
+  return db.query(`
+    SELECT source, COUNT(*) as count
+    FROM signup_notifications
+    GROUP BY source
+    ORDER BY count DESC
+  `).all() as { source: string; count: number }[];
+}
+
+export function getRecentSignupNotifications(
+  source?: string,
+  limit: number = 50
+): SignupNotification[] {
+  const safeLimit = Math.max(1, Math.min(200, Math.floor(limit)));
+  if (source) {
+    return db.query(`
+      SELECT id, email, source, interest, ip, created_at
+      FROM signup_notifications
+      WHERE source = ?
+      ORDER BY created_at DESC
+      LIMIT ?
+    `).all(source, safeLimit) as SignupNotification[];
+  }
+  return db.query(`
+    SELECT id, email, source, interest, ip, created_at
+    FROM signup_notifications
+    ORDER BY created_at DESC
+    LIMIT ?
+  `).all(safeLimit) as SignupNotification[];
 }
 
 export function logRevenue(apiName: string, amountUsd: number, txHash: string, network: string, payerWallet?: string) {

--- a/shared/logger.ts
+++ b/shared/logger.ts
@@ -42,7 +42,41 @@ export function apiLogger(apiName: string, priceUsd: number = 0): MiddlewareHand
     const userId = c.req.header("x-apimesh-user-id") || undefined;
     const apiKeyId = c.req.header("x-apimesh-key-id") || undefined;
 
-    logRequest(apiName, path, c.req.method, c.res.status, ms, paid, amount, clientIp, payerWallet, userId, apiKeyId, userAgent);
+    // Traffic attribution: where did this request come from?
+    // Strip query string + fragment from the Referer URL to avoid persisting
+    // accidental bearer tokens / session params from the upstream page's URL.
+    // (SECURITY-AUDIT M2.) Modern browsers usually strip these via Referer-Policy,
+    // but we don't trust client behavior — store only origin + pathname.
+    const refererRaw = c.req.header("referer") || c.req.header("referrer");
+    let referer: string | undefined;
+    if (refererRaw) {
+      try {
+        const r = new URL(refererRaw);
+        referer = sanitizeLogField(r.origin + r.pathname, 512);
+      } catch {
+        // Malformed referer — skip rather than store a junk value.
+      }
+    }
+    let utmSource: string | undefined;
+    let utmMedium: string | undefined;
+    let utmCampaign: string | undefined;
+    try {
+      const reqUrl = new URL(c.req.url);
+      const u = reqUrl.searchParams.get("utm_source");
+      const m = reqUrl.searchParams.get("utm_medium");
+      const cmp = reqUrl.searchParams.get("utm_campaign");
+      if (u) utmSource = sanitizeLogField(u, 128);
+      if (m) utmMedium = sanitizeLogField(m, 128);
+      if (cmp) utmCampaign = sanitizeLogField(cmp, 128);
+    } catch {
+      // Malformed URL — skip UTM extraction silently
+    }
+
+    logRequest(
+      apiName, path, c.req.method, c.res.status, ms,
+      paid, amount, clientIp, payerWallet, userId, apiKeyId, userAgent,
+      { referer, utmSource, utmMedium, utmCampaign }
+    );
 
     if (paid && amount > 0) {
       if (x402Paid) {

--- a/shared/signup-notify.ts
+++ b/shared/signup-notify.ts
@@ -1,0 +1,77 @@
+import type { Handler } from "hono";
+import { recordSignupNotification, SignupTableFullError } from "./db";
+import { normalizeEmail, validateEmail } from "./validation";
+
+export interface SignupNotifyConfig {
+  // Allowed (source, interest) combinations the endpoint will accept.
+  // The handler is mounted per-wedge, so each wedge restricts to its own
+  // legitimate combinations rather than letting any caller pick anything.
+  allowed: Array<{ source: string; interest: string }>;
+  // Origins the endpoint will accept browser-issued POSTs from. Same-origin
+  // (no Origin header) is always accepted — server-side callers / curl /
+  // older browsers don't send it. (SECURITY-AUDIT M1.)
+  allowedOrigins: string[];
+}
+
+const MAX_INTEREST_LEN = 64;
+const MAX_SOURCE_LEN = 64;
+const MAX_EMAIL_LEN = 254;
+
+export function signupNotifyHandler(config: SignupNotifyConfig): Handler {
+  const allowedSources = new Set(config.allowed.map(a => a.source));
+  const allowedPairs = new Set(config.allowed.map(a => `${a.source}|${a.interest}`));
+  const allowedOrigins = new Set(config.allowedOrigins);
+
+  return async (c) => {
+    // Origin pinning: a third-party page must not be able to subscribe a
+    // victim's email by issuing a cross-site POST. CORS alone doesn't
+    // prevent the side effect — only the response read.
+    const origin = c.req.header("origin");
+    if (origin && !allowedOrigins.has(origin)) {
+      return c.json({ error: "cross-origin request not allowed" }, 403);
+    }
+
+    let body: { email?: unknown; source?: unknown; interest?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+
+    if (typeof body.email !== "string" || body.email.length > MAX_EMAIL_LEN) {
+      return c.json({ error: "email (string) required" }, 400);
+    }
+    if (typeof body.source !== "string" || body.source.length > MAX_SOURCE_LEN) {
+      return c.json({ error: "source (string) required" }, 400);
+    }
+    if (typeof body.interest !== "string" || body.interest.length > MAX_INTEREST_LEN) {
+      return c.json({ error: "interest (string) required" }, 400);
+    }
+
+    if (!allowedSources.has(body.source)) {
+      return c.json({ error: "unknown source" }, 400);
+    }
+    if (!allowedPairs.has(`${body.source}|${body.interest}`)) {
+      return c.json({ error: "unknown interest for this source" }, 400);
+    }
+
+    const emailCheck = validateEmail(body.email);
+    if (!emailCheck.valid) {
+      return c.json({ error: emailCheck.error ?? "invalid email" }, 400);
+    }
+    const email = normalizeEmail(body.email);
+
+    const ipRaw = c.req.header("x-real-ip");
+    const ip = ipRaw && ipRaw.length <= 64 ? ipRaw : null;
+
+    try {
+      const inserted = recordSignupNotification(email, body.source, body.interest, ip);
+      return c.json({ ok: true, deduped: !inserted });
+    } catch (e) {
+      if (e instanceof SignupTableFullError) {
+        return c.json({ error: "signup list temporarily unavailable" }, 503);
+      }
+      throw e;
+    }
+  };
+}

--- a/tests/agentcontext/signup-notify.test.ts
+++ b/tests/agentcontext/signup-notify.test.ts
@@ -1,0 +1,146 @@
+// /signup-notify endpoint tests for the agentcontext wedge.
+// Mirrors tests/sigdebug/signup-notify.test.ts but with source=agentcontext +
+// interest=github-app. Uses a hermetic test Hono app to avoid pulling in
+// the wedge's full import graph (@mbeato/agentcontext parsers).
+
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { rateLimit } from "../../shared/rate-limit";
+import { signupNotifyHandler } from "../../shared/signup-notify";
+import db, { getRecentSignupNotifications } from "../../shared/db";
+
+const RL_ZONE = "test-agentcontext-signup-" + Date.now();
+// Marker domain so afterAll cleanup never touches a real signup. (CODE-REVIEW B1.)
+const TEST_DOMAIN = "@example.invalid";
+
+beforeAll(() => {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
+});
+
+afterAll(() => {
+  db.run(
+    `DELETE FROM signup_notifications WHERE source = 'agentcontext' AND email LIKE ?`,
+    [`%${TEST_DOMAIN}`],
+  );
+});
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use("/signup-notify", rateLimit(RL_ZONE, 5, 60_000));
+  app.post("/signup-notify", signupNotifyHandler({
+    allowed: [{ source: "agentcontext", interest: "github-app" }],
+    allowedOrigins: ["https://agentsmd.apimesh.xyz"],
+  }));
+  return app;
+}
+
+function makeReq(body: unknown, ip: string): Request {
+  return new Request("http://localhost/signup-notify", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-real-ip": ip },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+function uniqueEmail(): string {
+  return `agentcontext-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${TEST_DOMAIN}`;
+}
+
+describe("agentcontext /signup-notify", () => {
+  const app = buildApp();
+
+  test("valid email accepted, persisted with normalized casing", async () => {
+    const rawEmail = `  TestUser+ac@Example.INVALID  `;
+    const expected = "testuser+ac@example.invalid";
+    const res = await app.request(
+      makeReq({ email: rawEmail, source: "agentcontext", interest: "github-app" }, "10.1.0.1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+
+    const row = db
+      .query(
+        `SELECT email FROM signup_notifications
+         WHERE email = ? AND source = 'agentcontext'`,
+      )
+      .get(expected) as { email: string } | null;
+    expect(row).not.toBeNull();
+  });
+
+  test("malformed email rejected", async () => {
+    const res = await app.request(
+      makeReq({ email: "not-an-email", source: "agentcontext", interest: "github-app" }, "10.1.0.2"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("email without TLD rejected", async () => {
+    const res = await app.request(
+      makeReq({ email: "user@host", source: "agentcontext", interest: "github-app" }, "10.1.0.3"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("oversized email (>254 chars) rejected", async () => {
+    const huge = "a".repeat(250) + "@x.co";
+    const res = await app.request(
+      makeReq({ email: huge, source: "agentcontext", interest: "github-app" }, "10.1.0.4"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("dedupe by (email, source) — second insert is no-op", async () => {
+    const email = uniqueEmail();
+    const ip = "10.1.0.5";
+    const r1 = await app.request(
+      makeReq({ email, source: "agentcontext", interest: "github-app" }, ip),
+    );
+    expect(r1.status).toBe(200);
+    const b1 = await r1.json();
+    expect(b1.deduped).toBe(false);
+
+    const r2 = await app.request(
+      makeReq({ email, source: "agentcontext", interest: "github-app" }, ip),
+    );
+    expect(r2.status).toBe(200);
+    expect((await r2.json()).deduped).toBe(true);
+  });
+
+  test("rate-limit kicks in after 5 requests/min/IP", async () => {
+    const ip = "10.88.88.88";
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request(
+        makeReq({ email: uniqueEmail(), source: "agentcontext", interest: "github-app" }, ip),
+      );
+      expect(res.status).not.toBe(429);
+    }
+    const sixth = await app.request(
+      makeReq({ email: uniqueEmail(), source: "agentcontext", interest: "github-app" }, ip),
+    );
+    expect(sixth.status).toBe(429);
+  });
+
+  test("cross-origin POST rejected with 403", async () => {
+    const req = new Request("http://localhost/signup-notify", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-real-ip": "10.1.0.99",
+        "origin": "https://attacker.example.invalid",
+      },
+      body: JSON.stringify({
+        email: uniqueEmail(), source: "agentcontext", interest: "github-app",
+      }),
+    });
+    const res = await app.request(req);
+    expect(res.status).toBe(403);
+  });
+
+  test("getRecentSignupNotifications filtered by source returns only agentcontext rows", async () => {
+    const recent = getRecentSignupNotifications("agentcontext", 5);
+    for (const row of recent) {
+      expect(row.source).toBe("agentcontext");
+    }
+  });
+});

--- a/tests/sigdebug/signup-notify.test.ts
+++ b/tests/sigdebug/signup-notify.test.ts
@@ -1,0 +1,195 @@
+// /signup-notify endpoint tests for the sigdebug wedge.
+// Covers: valid email accepted, malformed rejected, dedup via INSERT OR IGNORE,
+// and rate-limit kicks in at the 6th request from a single IP within a minute.
+//
+// Tests run against a hermetic Hono app that mounts only the signup-notify
+// handler + its rate-limiter, so we don't pull in the rest of the wedge's
+// dependency graph (sig-verify, hints, etc).
+
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { rateLimit } from "../../shared/rate-limit";
+import { signupNotifyHandler } from "../../shared/signup-notify";
+import db, { getRecentSignupNotifications } from "../../shared/db";
+
+// Use a fresh rate-limit zone per test file so the bucket can't be polluted
+// by a sibling test file already in the same Bun test process.
+const RL_ZONE = "test-sigdebug-signup-" + Date.now();
+
+// Marker domain that real signups will never use. Used to scope afterAll
+// cleanup so we don't pollute the dev DB with test rows. (CODE-REVIEW B1.)
+const TEST_DOMAIN = "@example.invalid";
+
+beforeAll(() => {
+  // Set NODE_ENV=development so rate-limit accepts missing x-real-ip
+  // (it falls back to 127.0.0.1). We always pass x-real-ip explicitly,
+  // but this guards against test runners that strip env.
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
+});
+
+afterAll(() => {
+  db.run(
+    `DELETE FROM signup_notifications WHERE source = 'sigdebug' AND email LIKE ?`,
+    [`%${TEST_DOMAIN}`],
+  );
+});
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use("/signup-notify", rateLimit(RL_ZONE, 5, 60_000));
+  app.post("/signup-notify", signupNotifyHandler({
+    allowed: [{ source: "sigdebug", interest: "paid-tier" }],
+    allowedOrigins: ["https://stripesig.apimesh.xyz"],
+  }));
+  return app;
+}
+
+function makeReq(body: unknown, ip: string): Request {
+  return new Request("http://localhost/signup-notify", {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-real-ip": ip },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+function uniqueEmail(): string {
+  return `sigdebug-${Date.now()}-${Math.random().toString(36).slice(2, 8)}${TEST_DOMAIN}`;
+}
+
+describe("sigdebug /signup-notify", () => {
+  const app = buildApp();
+
+  test("valid email accepted, persisted to signup_notifications", async () => {
+    const email = uniqueEmail();
+    const res = await app.request(
+      makeReq({ email, source: "sigdebug", interest: "paid-tier" }, "10.0.0.1"),
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.ok).toBe(true);
+    expect(body.deduped).toBe(false);
+
+    const row = db
+      .query(
+        `SELECT email, source, interest FROM signup_notifications
+         WHERE email = ? AND source = 'sigdebug'`,
+      )
+      .get(email) as { email: string; source: string; interest: string } | null;
+    expect(row).not.toBeNull();
+    expect(row!.source).toBe("sigdebug");
+    expect(row!.interest).toBe("paid-tier");
+  });
+
+  test("malformed email rejected with 400", async () => {
+    const res = await app.request(
+      makeReq({ email: "not-an-email", source: "sigdebug", interest: "paid-tier" }, "10.0.0.2"),
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBeTruthy();
+  });
+
+  test("missing email rejected with 400", async () => {
+    const res = await app.request(
+      makeReq({ source: "sigdebug", interest: "paid-tier" }, "10.0.0.3"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("invalid JSON body rejected with 400", async () => {
+    const res = await app.request(
+      makeReq("not json{", "10.0.0.4"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("unknown source rejected", async () => {
+    const res = await app.request(
+      makeReq({ email: uniqueEmail(), source: "evil", interest: "paid-tier" }, "10.0.0.5"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("unknown interest rejected for valid source", async () => {
+    const res = await app.request(
+      makeReq({ email: uniqueEmail(), source: "sigdebug", interest: "free-tier-bypass" }, "10.0.0.6"),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("dedupe: second submission with same email returns deduped=true", async () => {
+    const email = uniqueEmail();
+    const ip = "10.0.0.7";
+    const r1 = await app.request(
+      makeReq({ email, source: "sigdebug", interest: "paid-tier" }, ip),
+    );
+    expect(r1.status).toBe(200);
+    expect((await r1.json()).deduped).toBe(false);
+
+    const r2 = await app.request(
+      makeReq({ email, source: "sigdebug", interest: "paid-tier" }, ip),
+    );
+    expect(r2.status).toBe(200);
+    expect((await r2.json()).deduped).toBe(true);
+
+    const rows = db
+      .query(
+        `SELECT COUNT(*) AS cnt FROM signup_notifications WHERE email = ? AND source = 'sigdebug'`,
+      )
+      .get(email) as { cnt: number };
+    expect(rows.cnt).toBe(1);
+  });
+
+  test("rate-limit kicks in after 5 requests/min from single IP", async () => {
+    // Use a dedicated IP so the 5-request budget isn't shared with other tests.
+    const ip = "10.99.99.99";
+    // First 5 should succeed (200 or 400 — what matters is that they're not 429).
+    for (let i = 0; i < 5; i++) {
+      const res = await app.request(
+        makeReq({ email: uniqueEmail(), source: "sigdebug", interest: "paid-tier" }, ip),
+      );
+      expect(res.status).not.toBe(429);
+    }
+    // 6th must be rate-limited.
+    const sixth = await app.request(
+      makeReq({ email: uniqueEmail(), source: "sigdebug", interest: "paid-tier" }, ip),
+    );
+    expect(sixth.status).toBe(429);
+  });
+
+  test("cross-origin POST blocked when Origin doesn't match allowlist", async () => {
+    const req = new Request("http://localhost/signup-notify", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-real-ip": "10.0.0.42",
+        "origin": "https://evil.example.invalid",
+      },
+      body: JSON.stringify({ email: uniqueEmail(), source: "sigdebug", interest: "paid-tier" }),
+    });
+    const res = await app.request(req);
+    expect(res.status).toBe(403);
+  });
+
+  test("cross-origin POST allowed when Origin matches allowlist", async () => {
+    const req = new Request("http://localhost/signup-notify", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-real-ip": "10.0.0.43",
+        "origin": "https://stripesig.apimesh.xyz",
+      },
+      body: JSON.stringify({ email: uniqueEmail(), source: "sigdebug", interest: "paid-tier" }),
+    });
+    const res = await app.request(req);
+    expect(res.status).toBe(200);
+  });
+
+  test("getRecentSignupNotifications filters by source", async () => {
+    const recent = getRecentSignupNotifications("sigdebug", 5);
+    expect(Array.isArray(recent)).toBe(true);
+    for (const row of recent) {
+      expect(row.source).toBe("sigdebug");
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- POST /signup-notify on both wedges (agentcontext, sigdebug). 5/min/IP, deduped by `UNIQUE(email, source)`, allowlist-validated source/interest pairs, origin-pinned.
- apiLogger now captures Referer (origin+pathname only — query/fragment stripped server-side) and `utm_source/medium/campaign` to four new columns on `requests`.
- Slim email-capture form on both landing pages (single field, no popup, no modal).
- Admin-gated dashboard tile under existing bearerAuth zone — shows count per source + 20 most-recent rows.
- Migration 010: new columns + `signup_notifications` table + supporting indices. `scripts/run-migrations.ts` is a one-line ssh runner if we want the schema landed before the code.
- 19 new tests in `tests/{sigdebug,agentcontext}/signup-notify.test.ts`. All pass.

## Why now
Day-30 hard exit clock = 2026-05-29. Wedges #1 and #2 went out yesterday in two cold-email batches (60 emails total). This PR lands the conversion measurement before any recipient opens the email tomorrow morning. Without it we'd have no way to know which inbox / link / UTM converted.

## Security + code review (parallel agents on the diff before merge)
Findings triaged and resolved in this PR:

| Bucket | Finding | Resolution |
|---|---|---|
| BLOCKING | Rate-limit ordering (`agentcontext`/`sigdebug` wildcard ran before signup-specific zone) | Signup zone now registered first |
| BLOCKING | Landing copy "we'll email you" promised something the handler doesn't do | Copy → "you're on the list" |
| BLOCKING (test) | Tests wrote to real `data/agent.db` with no cleanup | Tests use `@example.invalid` + `afterAll` cleanup |
| HIGH | `dashboard.js` double-encoded source via `esc()` then `textContent` | Removed `esc()` (textContent is the safety mechanism) |
| HIGH | `signup_notifications` could grow unbounded | `SIGNUP_MAX_ROWS=100_000` cap → 503 if breached |
| MEDIUM | CORS `*` + no origin check enabled cross-site POST CSRF | Handler now allowlists `Origin` header |
| MEDIUM | Referer with query string could leak third-party tokens | Strip query+fragment server-side before persist |
| LOW | No early-rejection length cap on `email` | Added 254-char cap before regex pass |

Verified safe: SQL injection (parameterized), CRLF/log injection (`sanitizeLogField` strips control chars), race on dedupe (`INSERT OR IGNORE` + UNIQUE atomic under WAL), stored XSS in dashboard (`esc()` applied in all `innerHTML` paths for signup rows), dashboard auth gating (signup tile is inside `bearerAuth`).

## Deploy checklist
1. Merge PR → `bash scripts/deploy.sh`.
2. After rsync, ssh to prod and run schema migration once: `ssh conway-prod 'cd /opt/conway-agent && DATA_DIR=/opt/conway-agent/data bun scripts/run-migrations.ts'`. Idempotent — safe to re-run.
3. Restart api-router service so the new columns/handler are live.
4. Smoke: POST a signup to `https://agentsmd.apimesh.xyz/signup-notify` and `https://stripesig.apimesh.xyz/signup-notify` from each wedge's own origin. Verify dashboard tile shows the row.

## Test plan
- [x] `bun test tests/sigdebug/signup-notify.test.ts tests/agentcontext/signup-notify.test.ts` — 19/19 pass
- [x] `bun test` — same 4 pre-existing failures as `main` (migrate.test.ts staleness + auth-rate-limit timing); confirmed by stashing this diff
- [ ] Live smoke after deploy (POST from each wedge origin returns 200; cross-origin POST returns 403)
- [ ] Dashboard tile populates after a real submit

## Out of scope
- No double-opt-in (call-out: Audit L3 — current list is pre-launch only; do not use for outreach without confirmation step)
- No prune job for `signup_notifications` (call-out: Audit H2 — 100k cap is the only ceiling for now; revisit if any wedge gets meaningful traffic)
- No GitHub App / paid-tier delivery wired up (these are the *targets* the email captures will alert on)