### PR TITLE
fix: redirect /mcp on wedges to mcp.apimesh.xyz

### DIFF
--- a/apis/agentcontext/index.ts
+++ b/apis/agentcontext/index.ts
@@ -75,6 +75,11 @@ app.post("/signup-notify", signupNotifyHandler({
   ],
 }));
 
+// MCP directory crawlers probe /mcp for HTTP-transport capability. The real
+// MCP gateway lives at mcp.apimesh.xyz (exposes agentcontext + every other
+// apimesh API as tools). 308 preserves POST method through the redirect.
+app.all("/mcp", (c) => c.redirect("https://mcp.apimesh.xyz/mcp", 308));
+
 // Free conversion endpoint. Accepts source content + format, returns rendered file map.
 // No auth — rate-limited only. Cap input size to prevent abuse.
 const MAX_INPUT_CHARS = 100_000;

--- a/apis/sigdebug/index.ts
+++ b/apis/sigdebug/index.ts
@@ -54,6 +54,10 @@ app.post("/signup-notify", signupNotifyHandler({
   ],
 }));
 
+// MCP directory crawlers probe /mcp for HTTP-transport capability. Redirect
+// (308 preserves POST) to the real apimesh MCP gateway.
+app.all("/mcp", (c) => c.redirect("https://mcp.apimesh.xyz/mcp", 308));
+
 const SUPPORTED_PROVIDERS: Provider[] = ["stripe", "github", "slack", "shopify"];
 const MAX_BODY_CHARS = 100_000;
 const MAX_SECRET_CHARS = 1_024;


### PR DESCRIPTION
## Summary
MCPScoringEngine/1.0 (a Hetzner-Oregon directory crawler) was probing `agentsmd.apimesh.xyz/mcp` ~hourly today and getting 404, since the wedge has no /mcp route. Same crawler ignores the other 95 apimesh APIs — the targeted probe is likely because `@mbeato/agentcontext-mcp` is published on npm without a corresponding HTTP MCP endpoint at the same domain.

This adds `app.all("/mcp", ...)` to both wedges (agentcontext + sigdebug) returning a **308 Permanent Redirect** (POST-preserving) to `https://mcp.apimesh.xyz/mcp`, where the real MCP gateway hosts all apimesh APIs as tools.

Effect: directory crawlers see a 3xx instead of 404 → don't de-rank the listing. Crawlers that follow redirects land on the actual MCP server.

## Test plan
- [x] curl `POST agentsmd.apimesh.xyz/mcp` returns 308 with Location header pointing at mcp.apimesh.xyz/mcp
- [x] curl `POST stripesig.apimesh.xyz/mcp` same
- [x] curl `POST mcp.apimesh.xyz/mcp` (the redirect target) responds normally