### PR TITLE
feat(wedges): demonstrate value before visitor interaction

### DIFF
--- a/apis/agentcontext/landing.html
+++ b/apis/agentcontext/landing.html
@@ -76,6 +76,48 @@
     Maintain <code>AGENTS.md</code> once, sync everything else.
   </p>
 
+  <div class="demo">
+    <div class="row">
+      <label for="src-fmt">Source:</label>
+      <select id="src-fmt">
+        <option value="claude-md" selected>CLAUDE.md</option>
+        <option value="agents-md">AGENTS.md</option>
+        <option value="gemini-md">GEMINI.md</option>
+        <option value="cursor-mdc">.cursor/rules/*.mdc</option>
+        <option value="cursor-legacy">.cursorrules (legacy)</option>
+        <option value="windsurf-mdc">.windsurf/rules/*.md</option>
+        <option value="windsurf-legacy">.windsurfrules (legacy)</option>
+        <option value="cline-file">.clinerules (file)</option>
+        <option value="conventions-md">CONVENTIONS.md</option>
+      </select>
+      <label for="tgt-fmt">→</label>
+      <select id="tgt-fmt">
+        <option value="agents-md" selected>AGENTS.md</option>
+        <option value="claude-md">CLAUDE.md</option>
+        <option value="gemini-md">GEMINI.md</option>
+        <option value="cursor-mdc">.cursor/rules/*.mdc</option>
+        <option value="windsurf-mdc">.windsurf/rules/*.md</option>
+        <option value="cline-dir">.clinerules/*.md</option>
+        <option value="conventions-md">CONVENTIONS.md</option>
+      </select>
+    </div>
+    <textarea id="src" placeholder="# Project rules&#10;&#10;- TypeScript strict mode&#10;- Bun for everything"># Project rules
+
+- Use TypeScript strict mode for all new code.
+- Bun for everything (no Node.js fallbacks).
+- Test before commit; CI is not a substitute for local testing.
+
+## Style
+
+- Lowercase commit messages.
+- Surgical changes: don't refactor outside the scope of the request.</textarea>
+    <div class="row">
+      <button id="convert-btn">Convert</button>
+      <span class="muted" id="status"></span>
+    </div>
+    <pre id="out">(output appears here)</pre>
+  </div>
+
   <h2>Why</h2>
   <p>
     Every AI coding tool invented its own rules-file format.
@@ -90,46 +132,6 @@
   <h2>Install</h2>
   <pre><code>npx @mbeato/agentcontext inspect</code></pre>
   <p class="muted">No install step. Runs against the current directory and prints a summary.</p>
-
-  <h2>Try it</h2>
-  <p>Paste a CLAUDE.md, .cursorrules, or any agent-context file. We'll normalize it to AGENTS.md.</p>
-
-  <div class="demo">
-    <div class="row">
-      <label for="src-fmt">Source:</label>
-      <select id="src-fmt">
-        <option value="agents-md">AGENTS.md</option>
-        <option value="claude-md">CLAUDE.md</option>
-        <option value="gemini-md">GEMINI.md</option>
-        <option value="cursor-mdc">.cursor/rules/*.mdc</option>
-        <option value="cursor-legacy">.cursorrules (legacy)</option>
-        <option value="windsurf-mdc">.windsurf/rules/*.md</option>
-        <option value="windsurf-legacy">.windsurfrules (legacy)</option>
-        <option value="cline-file">.clinerules (file)</option>
-        <option value="conventions-md">CONVENTIONS.md</option>
-      </select>
-      <label for="tgt-fmt">→</label>
-      <select id="tgt-fmt">
-        <option value="agents-md">AGENTS.md</option>
-        <option value="claude-md">CLAUDE.md</option>
-        <option value="gemini-md">GEMINI.md</option>
-        <option value="cursor-mdc">.cursor/rules/*.mdc</option>
-        <option value="windsurf-mdc">.windsurf/rules/*.md</option>
-        <option value="cline-dir">.clinerules/*.md</option>
-        <option value="conventions-md">CONVENTIONS.md</option>
-      </select>
-    </div>
-    <textarea id="src" placeholder="# Project rules&#10;&#10;- TypeScript strict mode&#10;- Bun for everything"># Project rules
-
-- Use TypeScript strict mode.
-- Bun for everything.
-- Test before commit.</textarea>
-    <div class="row">
-      <button id="convert-btn">Convert</button>
-      <span class="muted" id="status"></span>
-    </div>
-    <pre id="out">(output appears here)</pre>
-  </div>
 
   <h2>How it works</h2>
   <p>
@@ -230,6 +232,12 @@ npx @mbeato/agentcontext convert --from cursor-mdc --to agents-md --in .cursor/r
       } finally {
         notifyBtn.disabled = false;
       }
+    });
+
+    // Auto-fire the demo on page load so visitors see normalized output
+    // appear without having to scroll, click, or paste.
+    window.addEventListener('DOMContentLoaded', () => {
+      setTimeout(() => btn.click(), 500);
     });
 
     btn.addEventListener('click', async () => {

--- a/apis/sigdebug/landing.html
+++ b/apis/sigdebug/landing.html
@@ -211,7 +211,17 @@
       }
     };
 
-    function loadExample(name) {
+    async function hmacSha256Hex(key, data) {
+      const enc = new TextEncoder();
+      const cryptoKey = await crypto.subtle.importKey(
+        'raw', enc.encode(key), { name: 'HMAC', hash: 'SHA-256' }, false, ['sign']
+      );
+      const sig = await crypto.subtle.sign('HMAC', cryptoKey, enc.encode(data));
+      return Array.from(new Uint8Array(sig))
+        .map((b) => b.toString(16).padStart(2, '0')).join('');
+    }
+
+    async function loadExample(name) {
       const ex = EXAMPLES[name];
       if (!ex) return;
       document.getElementById('provider').value = ex.provider;
@@ -219,8 +229,12 @@
       document.getElementById('raw-body').value = ex.raw_body;
       let headers = ex.headers;
       if (headers.includes('__NOW__')) {
-        const now = Math.floor(Date.now() / 1000);
-        headers = headers.replace('__NOW__', String(now));
+        headers = headers.replace('__NOW__', String(Math.floor(Date.now() / 1000)));
+      }
+      if (headers.includes('__VALID__')) {
+        const t = Number((headers.match(/t=(\d+)/) || [])[1] || Math.floor(Date.now() / 1000));
+        const v1 = await hmacSha256Hex(ex.secret, t + '.' + ex.raw_body);
+        headers = headers.replace('__VALID__', v1);
       }
       document.getElementById('headers').value = headers;
       document.getElementById('output').innerHTML = '';
@@ -301,6 +315,15 @@
       div.textContent = String(s);
       return div.innerHTML;
     }
+
+    // Auto-load the wrong-secret example + run the check on page load. New
+    // visitors see "✗ Invalid signature → likely cause: you used a pk_ key"
+    // before doing anything, so the tool's diagnostic value is the first
+    // thing on screen.
+    window.addEventListener('DOMContentLoaded', async () => {
+      await loadExample('stripe-wrong-secret');
+      setTimeout(runCheck, 600);
+    });
 
     (function setupNotify() {
       const form = document.getElementById('notify-form');


### PR DESCRIPTION
## Why
0% conversion across ~22 humans from yesterday's GitHub-comment campaign. The wedges had functional demos but visitors had to scroll + type + click before seeing anything. This makes both demos demonstrate value before the visitor has to do anything.

## sigdebug
- Auto-load **wrong-secret** example on page load + auto-fire \`/check\`. Visitor sees \"✗ Invalid signature → likely cause: you used a pk_ key as webhook secret\" within ~600ms of landing. That's the diagnostic value the tool actually delivers.
- **Bug fix:** existing \`stripe-valid\` example had \`v1=__VALID__\` literal that was never substituted, so clicking \"stripe valid\" actually showed signature_mismatch. Added SubtleCrypto \`hmacSha256Hex()\` helper; \`loadExample\` now computes a real HMAC when \`__VALID__\` is present.

## agentcontext
- Move \`<div class=\"demo\">\` above Why+Install so it's the first thing below the lede.
- Default Source/Target to \`claude-md → agents-md\` (the #6235 pain the comment targeted).
- Pre-populate textarea with a richer CLAUDE.md sample.
- Auto-fire the convert button on \`DOMContentLoaded\` so the rendered AGENTS.md is on screen by the time the visitor finishes reading the lede.

## Tradeoff
Each visitor (including JS-rendering bots) consumes 1 \`/check\` or \`/normalize\` request. Real conversion signal becomes \`/signup-notify\` POSTs (humans-only — bots don't fill forms), not raw POST counts.

## Test plan
- [ ] Open \`agentsmd.apimesh.xyz\` in a fresh browser → \"Try it\" demo above Why → AGENTS.md output appears in the \`<pre>\` after ~500ms with no interaction
- [ ] Open \`stripesig.apimesh.xyz\` in a fresh browser → wrong-secret example fields populated → invalid verdict + hint appears after ~600ms
- [ ] Click \"stripe valid\" button → form populates with computed valid HMAC → \"Check signature →\" returns \`valid=true\`