### PR TITLE
feat(wedges): event tracking + dashboard funnel tile

### DIFF
--- a/apis/agentcontext/index.ts
+++ b/apis/agentcontext/index.ts
@@ -5,6 +5,16 @@ import { resolve } from "node:path";
 import { rateLimit } from "../../shared/rate-limit";
 import { apiLogger } from "../../shared/logger";
 import { signupNotifyHandler } from "../../shared/signup-notify";
+import { eventTrackHandler } from "../../shared/event-track";
+
+const AGENTCONTEXT_EVENTS = [
+  "page_load", "demo_visible", "demo_started",
+  "demo_success", "demo_error", "signup_focused",
+] as const;
+const AGENTCONTEXT_ORIGINS = [
+  "https://agentsmd.apimesh.xyz",
+  "https://agentcontext.apimesh.xyz",
+] as const;
 
 import {
   parseAgentsMd,
@@ -59,6 +69,7 @@ app.use("*", async (c, next) => {
 // is the binding constraint and doesn't also burn the 60/min wildcard.
 app.use("/normalize", rateLimit("agentcontext-normalize", 30, 60_000));
 app.use("/signup-notify", rateLimit("agentcontext-signup", 5, 60_000));
+app.use("/event", rateLimit("agentcontext-event", 30, 60_000));
 app.use("*", rateLimit("agentcontext", 60, 60_000));
 app.use("*", apiLogger(API_NAME, 0));
 
@@ -67,10 +78,13 @@ app.get("/", (c) => c.html(LANDING_HTML));
 
 app.post("/signup-notify", signupNotifyHandler({
   allowed: [{ source: "agentcontext", interest: "github-app" }],
-  allowedOrigins: [
-    "https://agentsmd.apimesh.xyz",
-    "https://agentcontext.apimesh.xyz",
-  ],
+  allowedOrigins: [...AGENTCONTEXT_ORIGINS],
+}));
+
+app.post("/event", eventTrackHandler({
+  source: "agentcontext",
+  allowedEvents: AGENTCONTEXT_EVENTS,
+  allowedOrigins: AGENTCONTEXT_ORIGINS,
 }));
 
 // MCP directory crawlers probe /mcp; the real gateway is mcp.apimesh.xyz.

--- a/apis/agentcontext/landing.html
+++ b/apis/agentcontext/landing.html
@@ -203,10 +203,23 @@ npx @mbeato/agentcontext convert --from cursor-mdc --to agents-md --in .cursor/r
     const out = document.getElementById('out');
     const status = document.getElementById('status');
 
+    // Fire-and-forget event tracking — sendBeacon survives page unload,
+    // fetch keepalive is the fallback. Failures are silent by design.
+    function track(event) {
+      try {
+        const body = JSON.stringify({ event });
+        const blob = new Blob([body], { type: 'application/json' });
+        if (navigator.sendBeacon && navigator.sendBeacon('/event', blob)) return;
+        fetch('/event', { method: 'POST', headers: { 'content-type': 'application/json' }, body, keepalive: true });
+      } catch {}
+    }
+
     const notifyForm = document.getElementById('notify-form');
     const notifyEmail = document.getElementById('notify-email');
     const notifyBtn = document.getElementById('notify-btn');
     const notifyStatus = document.getElementById('notify-status');
+
+    notifyEmail.addEventListener('focus', () => track('signup_focused'), { once: true });
 
     notifyForm.addEventListener('submit', async (e) => {
       e.preventDefault();
@@ -234,13 +247,7 @@ npx @mbeato/agentcontext convert --from cursor-mdc --to agents-md --in .cursor/r
       }
     });
 
-    // Auto-fire the demo on page load so visitors see normalized output
-    // appear without having to scroll, click, or paste.
-    window.addEventListener('DOMContentLoaded', () => {
-      setTimeout(() => btn.click(), 500);
-    });
-
-    btn.addEventListener('click', async () => {
+    async function convertOnce() {
       status.textContent = 'converting...';
       out.textContent = '';
       try {
@@ -257,6 +264,7 @@ npx @mbeato/agentcontext convert --from cursor-mdc --to agents-md --in .cursor/r
         if (!r.ok) {
           out.textContent = 'Error: ' + (data.error || r.statusText);
           status.textContent = '';
+          track('demo_error');
           return;
         }
         const lines = [];
@@ -271,10 +279,36 @@ npx @mbeato/agentcontext convert --from cursor-mdc --to agents-md --in .cursor/r
         }
         out.textContent = lines.join('\n') || '(empty)';
         status.textContent = 'done';
+        track('demo_success');
       } catch (e) {
         out.textContent = 'Error: ' + e.message;
         status.textContent = '';
+        track('demo_error');
       }
+    }
+
+    btn.addEventListener('click', () => {
+      track('demo_started');
+      convertOnce();
+    });
+
+    // demo_visible fires once when the demo box scrolls into view —
+    // distinguishes "saw it" from "loaded then bounced".
+    if ('IntersectionObserver' in window) {
+      const demoEl = document.querySelector('.demo');
+      if (demoEl) {
+        const obs = new IntersectionObserver((entries) => {
+          for (const e of entries) {
+            if (e.isIntersecting) { track('demo_visible'); obs.disconnect(); break; }
+          }
+        }, { threshold: 0.4 });
+        obs.observe(demoEl);
+      }
+    }
+
+    window.addEventListener('DOMContentLoaded', () => {
+      track('page_load');
+      setTimeout(convertOnce, 500);
     });
   </script>
 

--- a/apis/dashboard/dashboard.html
+++ b/apis/dashboard/dashboard.html
@@ -683,6 +683,29 @@
 
       <div class="panel">
         <div class="panel-header">
+          Wedge funnel (last 24h)
+          <span class="meta" id="wedge-events-summary" style="margin-left:12px;font-weight:400"></span>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Source</th>
+              <th>page_load</th>
+              <th>demo_visible</th>
+              <th>demo_started</th>
+              <th>demo_success</th>
+              <th>demo_error</th>
+              <th>signup_focused</th>
+            </tr>
+          </thead>
+          <tbody id="wedge-events-table">
+            <tr><td colspan="7" class="empty-state">No events yet</td></tr>
+          </tbody>
+        </table>
+      </div>
+
+      <div class="panel">
+        <div class="panel-header">
           Signup notifications
           <span class="meta" id="signup-summary" style="margin-left:12px;font-weight:400"></span>
         </div>

--- a/apis/dashboard/dashboard.js
+++ b/apis/dashboard/dashboard.js
@@ -314,6 +314,35 @@ function render(data) {
     }).join("");
   }
 
+  var ev = data.wedge_events_24h || [];
+  var evBySrc = {};
+  for (var i = 0; i < ev.length; i++) {
+    var row = ev[i];
+    if (!evBySrc[row.source]) evBySrc[row.source] = {};
+    evBySrc[row.source][row.event_type] = row.count;
+  }
+  var srcs = Object.keys(evBySrc).sort();
+  var evSummaryEl = document.getElementById("wedge-events-summary");
+  if (evSummaryEl) {
+    evSummaryEl.textContent = srcs.length === 0
+      ? "no events yet"
+      : srcs.map(function(s) { return s + ": " + (evBySrc[s].page_load || 0) + " loads"; }).join(" · ");
+  }
+  var evTb = document.getElementById("wedge-events-table");
+  if (evTb) {
+    if (srcs.length === 0) {
+      evTb.innerHTML = '<tr><td colspan="7" class="empty-state">No events yet</td></tr>';
+    } else {
+      var EV_COLS = ["page_load", "demo_visible", "demo_started", "demo_success", "demo_error", "signup_focused"];
+      evTb.innerHTML = srcs.map(function(s) {
+        var counts = evBySrc[s];
+        return '<tr><td class="primary">' + esc(s) + '</td>' +
+          EV_COLS.map(function(c) { return '<td class="mono">' + fmtN(counts[c] || 0) + '</td>'; }).join("") +
+          '</tr>';
+      }).join("");
+    }
+  }
+
   var sn = data.signup_notifications || { counts: [], recent: [] };
   var summaryEl = document.getElementById("signup-summary");
   if (summaryEl) {

--- a/apis/dashboard/index.ts
+++ b/apis/dashboard/index.ts
@@ -3,7 +3,7 @@ import { cors } from "hono/cors";
 import { bearerAuth } from "hono/bearer-auth";
 import { setCookie, getCookie, deleteCookie } from "hono/cookie";
 import { resolve, join } from "path";
-import db, { getRevenueByApi, getTotalRevenue, getRequestCount, getErrorRate, getApiRevenue, getRecentRequests, getActiveApis, getDailyRevenue, getDailyRequests, getHourlyRequests, getAuditLog, getWalletSummaries, getAllSpendCaps, upsertSpendCap, deleteSpendCap, getWalletSpend, getSpendCap, getApiDetailedStats, getApiRequests, getApiErrors, getApiStatusBreakdown, getSignupNotificationCounts, getRecentSignupNotifications } from "../../shared/db";
+import db, { getRevenueByApi, getTotalRevenue, getRequestCount, getErrorRate, getApiRevenue, getRecentRequests, getActiveApis, getDailyRevenue, getDailyRequests, getHourlyRequests, getAuditLog, getWalletSummaries, getAllSpendCaps, upsertSpendCap, deleteSpendCap, getWalletSpend, getSpendCap, getApiDetailedStats, getApiRequests, getApiErrors, getApiStatusBreakdown, getSignupNotificationCounts, getRecentSignupNotifications, getEventCounts } from "../../shared/db";
 import { WALLET_ADDRESS } from "../../shared/x402";
 import { rateLimit } from "../../shared/rate-limit";
 import { hashPassword, verifyPassword, createSession, getSession, deleteSession, deleteUserSessions, refreshSessionExpiry, logAuthEvent } from "../../shared/auth";
@@ -1714,6 +1714,7 @@ app.get("/api/stats", (c) => {
       counts: getSignupNotificationCounts(),
       recent: getRecentSignupNotifications(undefined, 20),
     },
+    wedge_events_24h: getEventCounts(24),
     charts: {
       daily_revenue_7d: getDailyRevenue(7),
       daily_revenue_30d: getDailyRevenue(30),

--- a/apis/sigdebug/index.ts
+++ b/apis/sigdebug/index.ts
@@ -5,6 +5,16 @@ import { resolve } from "node:path";
 import { rateLimit } from "../../shared/rate-limit";
 import { apiLogger } from "../../shared/logger";
 import { signupNotifyHandler } from "../../shared/signup-notify";
+import { eventTrackHandler } from "../../shared/event-track";
+
+const SIGDEBUG_EVENTS = [
+  "page_load", "demo_visible", "demo_started",
+  "demo_success", "demo_error", "signup_focused",
+] as const;
+const SIGDEBUG_ORIGINS = [
+  "https://stripesig.apimesh.xyz",
+  "https://sigdebug.apimesh.xyz",
+] as const;
 import { verify, type Provider, type VerifyInput } from "../../shared/sig-verify";
 import { generateHints } from "../../shared/sig-hints";
 
@@ -39,6 +49,7 @@ app.use("*", async (c, next) => {
 // effective on /check (SECURITY-AUDIT M1). One zone, one limit.
 // /signup-notify limit before the wildcard so it's the binding constraint.
 app.use("/signup-notify", rateLimit("sigdebug-signup", 5, 60_000));
+app.use("/event", rateLimit("sigdebug-event", 30, 60_000));
 app.use("*", rateLimit("sigdebug", 60, 60_000));
 app.use("*", apiLogger(API_NAME, 0));
 
@@ -46,10 +57,13 @@ app.get("/", (c) => c.html(LANDING_HTML));
 
 app.post("/signup-notify", signupNotifyHandler({
   allowed: [{ source: "sigdebug", interest: "paid-tier" }],
-  allowedOrigins: [
-    "https://stripesig.apimesh.xyz",
-    "https://sigdebug.apimesh.xyz",
-  ],
+  allowedOrigins: [...SIGDEBUG_ORIGINS],
+}));
+
+app.post("/event", eventTrackHandler({
+  source: "sigdebug",
+  allowedEvents: SIGDEBUG_EVENTS,
+  allowedOrigins: SIGDEBUG_ORIGINS,
 }));
 
 // MCP directory crawlers probe /mcp; the real gateway is mcp.apimesh.xyz.

--- a/apis/sigdebug/landing.html
+++ b/apis/sigdebug/landing.html
@@ -139,7 +139,7 @@
       <textarea id="headers" spellcheck="false" placeholder="Stripe-Signature: t=1577836800,v1=abc..."></textarea>
     </div>
 
-    <button id="check-btn" onclick="runCheck()">Check signature →</button>
+    <button id="check-btn" onclick="userRunCheck()">Check signature →</button>
   </div>
 
   <div id="output"></div>
@@ -184,6 +184,15 @@
   </footer>
 
   <script>
+    function track(event) {
+      try {
+        const body = JSON.stringify({ event });
+        const blob = new Blob([body], { type: 'application/json' });
+        if (navigator.sendBeacon && navigator.sendBeacon('/event', blob)) return;
+        fetch('/event', { method: 'POST', headers: { 'content-type': 'application/json' }, body, keepalive: true });
+      } catch {}
+    }
+
     const EXAMPLES = {
       'stripe-valid': {
         provider: 'stripe',
@@ -272,12 +281,21 @@
         const data = await r.json();
         if (!r.ok) {
           out.innerHTML = '<div class="verdict invalid">Error: ' + escapeHtml(data.error || r.statusText) + '</div>';
+          track('demo_error');
           return;
         }
         renderResult(data);
+        track('demo_success');
       } catch (e) {
         out.innerHTML = '<div class="verdict invalid">Network error: ' + escapeHtml(e.message) + '</div>';
+        track('demo_error');
       }
+    }
+
+    // User-initiated check (button click) — track separately from auto-fire.
+    function userRunCheck() {
+      track('demo_started');
+      runCheck();
     }
 
     function renderResult(data) {
@@ -321,15 +339,29 @@
     // before doing anything, so the tool's diagnostic value is the first
     // thing on screen.
     window.addEventListener('DOMContentLoaded', async () => {
+      track('page_load');
       await loadExample('stripe-wrong-secret');
       setTimeout(runCheck, 600);
     });
+
+    if ('IntersectionObserver' in window) {
+      const formEl = document.querySelector('.form');
+      if (formEl) {
+        const obs = new IntersectionObserver((entries) => {
+          for (const e of entries) {
+            if (e.isIntersecting) { track('demo_visible'); obs.disconnect(); break; }
+          }
+        }, { threshold: 0.4 });
+        obs.observe(formEl);
+      }
+    }
 
     (function setupNotify() {
       const form = document.getElementById('notify-form');
       const emailInput = document.getElementById('notify-email');
       const btn = document.getElementById('notify-btn');
       const statusEl = document.getElementById('notify-status');
+      emailInput.addEventListener('focus', () => track('signup_focused'), { once: true });
       form.addEventListener('submit', async (e) => {
         e.preventDefault();
         const email = (emailInput.value || '').trim();

--- a/data/migrations/011_events.sql
+++ b/data/migrations/011_events.sql
@@ -1,0 +1,17 @@
+-- Migration 011: events table for wedge funnel analytics.
+-- Captures coarse interaction signals (page_load, demo_started, demo_success,
+-- signup_focused, etc) so we can see WHERE in the page visitors fall off,
+-- not just whether they hit the entry endpoint.
+
+CREATE TABLE IF NOT EXISTS events (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  source TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  client_ip TEXT,
+  user_agent TEXT,
+  created_at TEXT DEFAULT (datetime('now'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_events_source ON events(source);
+CREATE INDEX IF NOT EXISTS idx_events_event_type ON events(event_type);
+CREATE INDEX IF NOT EXISTS idx_events_source_type_created ON events(source, event_type, created_at DESC);

--- a/shared/db.ts
+++ b/shared/db.ts
@@ -135,6 +135,33 @@ export function getRecentSignupNotifications(
   `).all(safeLimit) as SignupNotification[];
 }
 
+// --- Wedge funnel events ---
+
+export type EventCounts = Array<{ source: string; event_type: string; count: number }>;
+
+export function recordEvent(
+  source: string,
+  eventType: string,
+  clientIp: string | null,
+  userAgent: string | null,
+): void {
+  db.run(
+    `INSERT INTO events (source, event_type, client_ip, user_agent) VALUES (?, ?, ?, ?)`,
+    [source, eventType, clientIp, userAgent],
+  );
+}
+
+export function getEventCounts(hoursBack: number = 24): EventCounts {
+  const safeHours = Math.max(1, Math.min(720, Math.floor(hoursBack)));
+  return db.query(`
+    SELECT source, event_type, COUNT(*) AS count
+    FROM events
+    WHERE created_at > datetime('now', '-' || ? || ' hours')
+    GROUP BY source, event_type
+    ORDER BY source, count DESC
+  `).all(safeHours) as EventCounts;
+}
+
 export function logRevenue(apiName: string, amountUsd: number, txHash: string, network: string, payerWallet?: string) {
   db.run(
     `INSERT INTO revenue (api_name, amount_usd, tx_hash, network, payer_wallet) VALUES (?, ?, ?, ?, ?)`,

--- a/shared/event-track.ts
+++ b/shared/event-track.ts
@@ -1,0 +1,48 @@
+import type { Handler } from "hono";
+import { recordEvent } from "./db";
+
+export interface EventTrackConfig {
+  source: string;
+  // Allowlist of event_type strings the endpoint will accept. Anything else
+  // is rejected — keeps untrusted clients from filling the table with junk.
+  allowedEvents: readonly string[];
+  // Origins accepted for browser-issued POSTs. Same-origin / no-Origin
+  // (curl, server-side) is always accepted.
+  allowedOrigins: readonly string[];
+}
+
+const MAX_EVENT_LEN = 64;
+
+export function eventTrackHandler(config: EventTrackConfig): Handler {
+  const allowed = new Set(config.allowedEvents);
+  const allowedOrigins = new Set(config.allowedOrigins);
+
+  return async (c) => {
+    const origin = c.req.header("origin");
+    if (origin && !allowedOrigins.has(origin)) {
+      return c.json({ error: "cross-origin request not allowed" }, 403);
+    }
+
+    let body: { event?: unknown };
+    try {
+      body = await c.req.json();
+    } catch {
+      return c.json({ error: "invalid JSON body" }, 400);
+    }
+
+    if (typeof body.event !== "string" || body.event.length > MAX_EVENT_LEN) {
+      return c.json({ error: "event (string) required" }, 400);
+    }
+    if (!allowed.has(body.event)) {
+      return c.json({ error: "unknown event" }, 400);
+    }
+
+    const ipRaw = c.req.header("x-real-ip");
+    const ip = ipRaw && ipRaw.length <= 64 ? ipRaw : null;
+    const uaRaw = c.req.header("user-agent");
+    const ua = uaRaw ? uaRaw.slice(0, 256) : null;
+
+    recordEvent(config.source, body.event, ip, ua);
+    return c.json({ ok: true });
+  };
+}

--- a/tests/event-track.test.ts
+++ b/tests/event-track.test.ts
@@ -1,0 +1,113 @@
+// /event endpoint tests. Same hermetic Hono+rate-limit pattern as the
+// signup-notify suite. Cleaned up via afterAll using a unique source marker
+// so test rows can't pollute the dev DB.
+
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { Hono } from "hono";
+import { rateLimit } from "../shared/rate-limit";
+import { eventTrackHandler } from "../shared/event-track";
+import db, { getEventCounts } from "../shared/db";
+
+const RL_ZONE = "test-event-track-" + Date.now();
+const TEST_SOURCE = `test-event-${Date.now()}`;
+const ALLOWED = ["page_load", "demo_visible", "demo_started", "demo_success", "demo_error", "signup_focused"] as const;
+
+beforeAll(() => {
+  process.env.NODE_ENV = process.env.NODE_ENV ?? "development";
+});
+
+afterAll(() => {
+  db.run(`DELETE FROM events WHERE source = ?`, [TEST_SOURCE]);
+});
+
+function buildApp(): Hono {
+  const app = new Hono();
+  app.use("/event", rateLimit(RL_ZONE, 30, 60_000));
+  app.post("/event", eventTrackHandler({
+    source: TEST_SOURCE,
+    allowedEvents: ALLOWED,
+    allowedOrigins: ["https://stripesig.apimesh.xyz"],
+  }));
+  return app;
+}
+
+function makeReq(body: unknown, ip: string, origin?: string): Request {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+    "x-real-ip": ip,
+    "user-agent": "test/1.0",
+  };
+  if (origin) headers.origin = origin;
+  return new Request("http://localhost/event", {
+    method: "POST",
+    headers,
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("/event", () => {
+  const app = buildApp();
+
+  test("valid event accepted, persisted to events table", async () => {
+    const res = await app.request(makeReq({ event: "page_load" }, "10.5.0.1"));
+    expect(res.status).toBe(200);
+    expect((await res.json()).ok).toBe(true);
+
+    const rows = db
+      .query(`SELECT event_type, user_agent FROM events WHERE source = ? ORDER BY id DESC LIMIT 1`)
+      .get(TEST_SOURCE) as { event_type: string; user_agent: string } | null;
+    expect(rows).not.toBeNull();
+    expect(rows!.event_type).toBe("page_load");
+    expect(rows!.user_agent).toBe("test/1.0");
+  });
+
+  test("unknown event rejected", async () => {
+    const res = await app.request(makeReq({ event: "drop_table" }, "10.5.0.2"));
+    expect(res.status).toBe(400);
+  });
+
+  test("missing event field rejected", async () => {
+    const res = await app.request(makeReq({}, "10.5.0.3"));
+    expect(res.status).toBe(400);
+  });
+
+  test("invalid JSON rejected", async () => {
+    const res = await app.request(makeReq("not json{", "10.5.0.4"));
+    expect(res.status).toBe(400);
+  });
+
+  test("oversized event name rejected", async () => {
+    const res = await app.request(makeReq({ event: "x".repeat(100) }, "10.5.0.5"));
+    expect(res.status).toBe(400);
+  });
+
+  test("cross-origin POST rejected when Origin doesn't match allowlist", async () => {
+    const res = await app.request(
+      makeReq({ event: "page_load" }, "10.5.0.6", "https://evil.example.invalid"),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("rate-limit kicks in past 30/min/IP", async () => {
+    const ip = "10.99.0.1";
+    for (let i = 0; i < 30; i++) {
+      const res = await app.request(makeReq({ event: "page_load" }, ip));
+      expect(res.status).not.toBe(429);
+    }
+    const overflow = await app.request(makeReq({ event: "page_load" }, ip));
+    expect(overflow.status).toBe(429);
+  });
+
+  test("getEventCounts groups by source + event_type", async () => {
+    await app.request(makeReq({ event: "demo_started" }, "10.5.0.10"));
+    await app.request(makeReq({ event: "demo_started" }, "10.5.0.11"));
+    await app.request(makeReq({ event: "demo_success" }, "10.5.0.12"));
+
+    const counts = getEventCounts(24);
+    const ours = counts.filter((c) => c.source === TEST_SOURCE);
+    const started = ours.find((c) => c.event_type === "demo_started");
+    const success = ours.find((c) => c.event_type === "demo_success");
+    expect((started?.count ?? 0) >= 2).toBe(true);
+    expect((success?.count ?? 0) >= 1).toBe(true);
+  });
+});


### PR DESCRIPTION
## Why
Phase 1 (the previous PR) made the wedge demos auto-fire so visitors see value before interacting. Phase 2 adds the measurement layer so we can tell WHICH step (saw the page, saw the demo, clicked the button, got a result, focused the signup form) is the actual drop-off point.

## What
- New POST `/event` endpoint per wedge (allowlist-validated, rate-limited 30/min/IP, origin-pinned, no auth needed for browser POSTs).
- 6 events instrumented per wedge: `page_load`, `demo_visible` (IntersectionObserver), `demo_started`, `demo_success`, `demo_error`, `signup_focused`.
- Tracking is `navigator.sendBeacon` with `fetch+keepalive` fallback — fire-and-forget.
- Migration 011 adds `events` table + composite (source, event_type, created_at) index.
- New "Wedge funnel (last 24h)" panel on the admin dashboard, included in the existing bearer-auth-gated `/api/stats` payload.

## Tradeoffs / known limits
- Only humans submit forms, but bots that render JS will fire `page_load`. Cleanest signal remains `signup_focused` (no bot does that). All counts should be read accordingly.
- Auto-fire on landing fires `demo_success` too — distinguish this from intent by reading `demo_started` (only user clicks).
- Events table grows linearly with traffic; no row cap or prune yet (vs signup_notifications which has 100k cap). At current scale fine; revisit if traffic grows.

## Test plan
- [x] `bun test tests/event-track.test.ts` → 8/8 pass
- [x] `bun test` → 248 pass (same 4 pre-existing failures, unrelated)
- [ ] After deploy: open agentsmd in fresh browser → check dashboard tile shows page_load + demo_visible + demo_success counts
- [ ] After deploy: focus the signup-notify email field → check signup_focused increments