### PR TITLE
fix(sigdebug): repair literal-backslash escapes that broke JS parse

### DIFF
--- a/apis/sigdebug/landing.html
+++ b/apis/sigdebug/landing.html
@@ -600,7 +600,7 @@
       },
       'github-valid': {
         provider: 'github',
-        secret: 'It\\'s a Secret to Everybody',
+        secret: "It's a Secret to Everybody",
         raw_body: 'Hello, World!',
         headers: 'X-Hub-Signature-256: sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17'
       }
@@ -637,7 +637,7 @@
 
     function parseHeaders(text) {
       const out = {};
-      for (const line of text.split('\\n')) {
+      for (const line of text.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed) continue;
         const idx = trimmed.indexOf(':');


### PR DESCRIPTION
Inherited from previous landing.html and preserved "verbatim" through the rebuild. Two broken escapes (line 603: `'It\\\'s ...'`, line 640: `split('\\\\n')`) caused the inline script to fail to parse — no globals defined, auto-fire never ran, demo silently empty. agentcontext was unaffected. Caught via browser_evaluate verification.